### PR TITLE
refactor: 로그인/회원가입 단계별 로직 분리 및 메일 인증 기능 추가

### DIFF
--- a/yourtrip/build.gradle
+++ b/yourtrip/build.gradle
@@ -31,6 +31,8 @@ dependencies {
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
     implementation 'org.hibernate.validator:hibernate-validator:8.0.1.Final'
 
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/yourtrip/src/main/java/backend/yourtrip/domain/user/controller/UserController.java
+++ b/yourtrip/src/main/java/backend/yourtrip/domain/user/controller/UserController.java
@@ -4,33 +4,353 @@ import backend.yourtrip.domain.user.dto.request.*;
 import backend.yourtrip.domain.user.dto.response.*;
 import backend.yourtrip.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
+/**
+ * UserController
+ *
+ * 회원 관련 API (이메일 회원가입 단계 / 로그인 / 토큰 재발급)
+ * - 피그마 플로우: 이메일 입력 -> 인증번호 입력 -> 비밀번호 설정 -> 프로필 등록(최종 가입)
+ * - 각 엔드포인트에 제약조건, 에러처리, 테스트 방법을 Swagger 문서에 상세 기재
+ */
+
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/users")
-@Tag(name = "User API", description = "회원가입 및 로그인 API")
+@Tag(name = "User API", description = "회원가입 단계/로그인/토큰 재발급 API")
 public class UserController {
 
     private final UserService userService;
 
-    @Operation(summary = "회원가입 API")
-    @ResponseStatus(HttpStatus.CREATED)
-    @PostMapping("/signup")
-    public UserSignupResponse signup(@RequestBody UserSignupRequest request) {
-        return userService.signup(request);
+    // =========================================================
+    // 1. 이메일 인증번호 발송
+    // =========================================================
+    @Operation(
+        summary = "이메일 인증번호 발송",
+        description = """
+        ### 제약조건
+        - 이메일은 **RFC 5322** 형식이어야 하며, **이미 가입된 이메일에는 발송 불가**합니다.
+        - 동일 이메일로 재요청 시 **가장 마지막으로 발급된 인증번호**만 유효합니다.
+        - 인증번호는 6자리 숫자, 유효시간 기본 **5분**
+
+        ### 예외상황 / 에러코드
+        - `EMAIL_ALREADY_EXIST(400)`: 이미 가입된 이메일로 요청.
+        - `INVALID_REQUEST_FIELD(400)`: 이메일 형식 불일치 또는 빈 값.
+
+        ### 테스트 방법
+        1. Swagger에서 **POST** `/api/users/email/send` 실행
+        2. 요청 예시:
+        ```json
+        {
+          "email": "newuser@example.com"
+        }
+        ```
+        3. 정상: **200 OK**(본문 없음). 콘솔/메일 수신함에서 인증번호 확인(개발 단계는 서버 로그로 노출).
+        """
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "인증번호 발송 성공(본문 없음)"),
+        @ApiResponse(responseCode = "400", description = "중복 이메일/형식 오류",
+            content = @Content(mediaType = "application/json",
+                examples = @ExampleObject(value = """
+                {
+                  "timestamp": "2025-11-11T10:00:00",
+                  "code": "EMAIL_ALREADY_EXIST",
+                  "message": "이미 가입된 이메일입니다."
+                }
+                """)))
+    })
+    @PostMapping("/email/send")
+    @ResponseStatus(HttpStatus.OK)
+    public void sendVerificationCode(@RequestBody EmailSendRequest request) {
+        userService.sendVerificationCode(request.email());
     }
 
-    @Operation(summary = "로그인 API")
+    // =========================================================
+    // 2. 인증번호 검증
+    // =========================================================
+    @Operation(
+        summary = "이메일 인증번호 검증",
+        description = """
+        ### 제약조건
+        - 요청 본문에 **email**과 **code(6자리)** 모두 필수입니다.
+        - 올바른 코드라도 유효시간이 지나면 실패합니다.
+
+        ### 예외상황 / 에러코드
+        - `INVALID_VERIFICATION_CODE(400)`: 코드 불일치.
+        - `VERIFICATION_CODE_EXPIRED(400)`: 코드 만료 또는 미발급.
+        - `INVALID_REQUEST_FIELD(400)`: 필드 누락/형식 오류.
+
+        ### 테스트 방법
+        1. 이메일로 수신한 인증번호를 입력해 **POST** `/api/users/email/verify` 요청
+        2. 요청 예시:
+        ```json
+        { "email": "newuser@example.com", "code": "123456" }
+        ```
+        3. 정상: **200 OK**(본문 없음). 이후 단계(비밀번호 설정) 진행 가능.
+        """
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "인증 성공(본문 없음)"),
+        @ApiResponse(responseCode = "400", description = "코드 오류/만료/필드 오류",
+            content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "코드 불일치", value = """
+                {
+                  "timestamp": "2025-11-11T10:03:00",
+                  "code": "INVALID_VERIFICATION_CODE",
+                  "message": "인증번호가 올바르지 않습니다."
+                }
+                """),
+                @ExampleObject(name = "코드 만료", value = """
+                {
+                  "timestamp": "2025-11-11T10:04:00",
+                  "code": "VERIFICATION_CODE_EXPIRED",
+                  "message": "인증번호가 만료되었습니다."
+                }
+                """)
+            }))
+    })
+    @PostMapping("/email/verify")
+    @ResponseStatus(HttpStatus.OK)
+    public void verifyCode(@RequestBody EmailVerifyRequest request) {
+        userService.verifyCode(request.email(), request.code());
+    }
+
+    // =========================================================
+    // 3. 비밀번호 설정
+    // =========================================================
+    @Operation(
+        summary = "비밀번호 설정",
+        description = """
+        ### 제약조건
+        - **이메일 인증(2단계)이 완료된 이메일**만 비밀번호를 설정할 수 있습니다.
+        - 비밀번호 정책(문서 기준):
+          - 최소 **8자 이상**
+          - 공백 불가
+          - 영문/숫자/특수문자 조합 권장
+
+        ### 예외상황 / 에러코드
+        - `EMAIL_NOT_VERIFIED(400)`: 이메일 인증 미완료 상태에서 요청.
+        - `INVALID_REQUEST_FIELD(400)`: 비밀번호 형식 위반/필드 누락.
+
+        ### 테스트 방법
+        1. **POST** `/api/users/password`
+        2. 요청 예시:
+        ```json
+        { "email": "newuser@example.com", "password": "Abcd1234!" }
+        ```
+        3. 정상: **200 OK**(본문 없음). 이후 프로필 등록 단계 진행.
+        """
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "비밀번호 설정 성공(본문 없음)"),
+        @ApiResponse(responseCode = "400", description = "미인증/형식 오류",
+            content = @Content(mediaType = "application/json",
+                examples = @ExampleObject(value = """
+                {
+                  "timestamp": "2025-11-11T10:05:00",
+                  "code": "EMAIL_NOT_VERIFIED",
+                  "message": "이메일 인증이 완료되지 않았습니다."
+                }
+                """)))
+    })
+    @PostMapping("/password")
+    @ResponseStatus(HttpStatus.OK)
+    public void setPassword(@RequestBody PasswordSetRequest request) {
+        userService.setPassword(request.email(), request.password());
+    }
+
+    // =========================================================
+    // 4. 프로필 등록 (최종 회원가입 완료)
+    // =========================================================
+    @Operation(
+        summary = "프로필 등록(최종 회원가입 완료)",
+        description = """
+        ### 제약조건
+        - 닉네임: **1~20자**
+        - 프로필 이미지는 선택값(`profileImageUrl`), 미지정 시 서버 기본값 사용 가능(정책에 따름).
+        - 비밀번호가 **사전 설정(3단계)** 되어 있어야 최종 회원 생성이 됩니다.
+
+        ### 예외상황 / 에러코드
+        - `EMAIL_NOT_VERIFIED(400)`: 이메일 인증 미완료.
+        - `INVALID_REQUEST_FIELD(400)`: 닉네임 규칙 위반/필드 누락.
+        - `USER_NOT_FOUND(404)`: 내부 임시 정보 미존재 등으로 가입 완료 불가.
+        - `EMAIL_ALREADY_EXIST(400)`: 경합 상황에서 동일 이메일이 이미 가입 완료된 경우.
+
+        ### 테스트 방법
+        1. **POST** `/api/users/profile`
+        2. 요청 예시:
+        ```json
+        {
+          "email": "newuser@example.com",
+          "nickname": "여행러버",
+          "profileImageUrl": "https://cdn.example.com/profile.png"
+        }
+        ```
+        3. 정상: **201 Created** + 가입 사용자 정보 반환.
+        4. 응답 예시:
+        ```json
+        {
+          "userId": 1,
+          "email": "newuser@example.com",
+          "nickname": "여행러버",
+          "createdAt": "2025-11-11T10:06:00"
+        }
+        ```
+        """
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", description = "가입 완료",
+            content = @Content(schema = @Schema(implementation = UserSignupResponse.class),
+                examples = @ExampleObject(value = """
+                {
+                  "userId": 1,
+                  "email": "newuser@example.com",
+                  "nickname": "여행러버",
+                  "createdAt": "2025-11-11T10:06:00"
+                }
+                """))),
+        @ApiResponse(responseCode = "400", description = "미인증/필드 오류/중복",
+            content = @Content(mediaType = "application/json",
+                examples = @ExampleObject(value = """
+                {
+                  "timestamp": "2025-11-11T10:06:30",
+                  "code": "EMAIL_NOT_VERIFIED",
+                  "message": "이메일 인증이 완료되지 않았습니다."
+                }
+                """))),
+        @ApiResponse(responseCode = "404", description = "임시 가입 정보 없음",
+            content = @Content(mediaType = "application/json",
+                examples = @ExampleObject(value = """
+                {
+                  "timestamp": "2025-11-11T10:06:40",
+                  "code": "USER_NOT_FOUND",
+                  "message": "사용자를 찾을 수 없습니다."
+                }
+                """)))
+    })
+    @PostMapping("/profile")
+    @ResponseStatus(HttpStatus.CREATED)
+    public UserSignupResponse completeSignup(@RequestBody ProfileCreateRequest request) {
+        return userService.completeSignup(request);
+    }
+
+    // =========================================================
+    // 5. 로그인
+    // =========================================================
+    @Operation(
+        summary = "이메일 로그인",
+        description = """
+        ### 제약조건
+        - **email**/**password** 모두 필수입니다.
+
+        ### 예외상황 / 에러코드
+        - `EMAIL_NOT_FOUND(400)`: 가입되지 않은 이메일.
+        - `NOT_MATCH_PASSWORD(400)`: 비밀번호 불일치.
+
+        ### 테스트 방법
+        1. **POST** `/api/users/login`
+        2. 요청 예시:
+        ```json
+        { "email": "newuser@example.com", "password": "Abcd1234!" }
+        ```
+        3. 정상: **200 OK** + Access Token 반환.
+        4. 응답 예시:
+        ```json
+        {
+          "userId": 1,
+          "nickname": "여행러버",
+          "accessToken": "eyJhbGciOi..."
+        }
+        ```
+        - Swagger의 **Authorize** 버튼에 `Bearer {accessToken}` 입력 후 인증이 필요한 API 호출 가능.
+        """
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "로그인 성공",
+            content = @Content(schema = @Schema(implementation = UserLoginResponse.class))),
+        @ApiResponse(responseCode = "400", description = "이메일/비밀번호 오류",
+            content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "이메일 없음", value = """
+                {
+                  "timestamp": "2025-11-11T10:08:00",
+                  "code": "EMAIL_NOT_FOUND",
+                  "message": "존재하지 않는 이메일입니다."
+                }
+                """),
+                @ExampleObject(name = "비밀번호 불일치", value = """
+                {
+                  "timestamp": "2025-11-11T10:08:10",
+                  "code": "NOT_MATCH_PASSWORD",
+                  "message": "비밀번호가 일치하지 않습니다."
+                }
+                """)
+            }))
+    })
     @PostMapping("/login")
     public UserLoginResponse login(@RequestBody UserLoginRequest request) {
         return userService.login(request);
     }
 
-    @Operation(summary = "Access Token 재발급 API")
+    // =========================================================
+    // 6. Access Token 재발급
+    // =========================================================
+    @Operation(
+        summary = "Access Token 재발급",
+        description = """
+        ### 제약조건
+        - **Authorization 헤더**로 **Refresh Token(원문 그대로)** 을 전달합니다.
+          - 예) `Authorization: {refreshToken}`
+          - (주의) `Bearer ` 접두어 **붙이지 않습니다**. 서버 구현이 원문 토큰을 기대합니다.
+
+        ### 예외상황 / 에러코드
+        - `INVALID_REFRESH_TOKEN(400)`: 위변조/만료 등으로 토큰이 유효하지 않음.
+        - `NOT_MATCH_REFRESH_TOKEN(400)`: 서버에 저장된 Refresh Token과 불일치.
+
+        ### 테스트 방법
+        1. 로그인 성공 시 응답 본문에 포함된 **refreshToken**(서버 내부 저장)을 사용.
+           - 현재 API는 새 Access Token만 응답합니다.
+        2. **POST** `/api/users/refresh` 에 `Authorization` 헤더로 Refresh Token 전달.
+        3. 정상: **200 OK** + 새 Access Token 반환.
+        4. 응답 예시:
+        ```json
+        {
+          "userId": 1,
+          "nickname": "여행러버",
+          "accessToken": "eyJhbGciOi...new"
+        }
+        ```
+        """
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "재발급 성공",
+            content = @Content(schema = @Schema(implementation = UserLoginResponse.class))),
+        @ApiResponse(responseCode = "400", description = "리프레시 토큰 오류",
+            content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "유효하지 않음", value = """
+                {
+                  "timestamp": "2025-11-11T10:09:00",
+                  "code": "INVALID_REFRESH_TOKEN",
+                  "message": "유효하지 않은 리프레시 토큰입니다."
+                }
+                """),
+                @ExampleObject(name = "서버 저장값과 불일치", value = """
+                {
+                  "timestamp": "2025-11-11T10:09:10",
+                  "code": "NOT_MATCH_REFRESH_TOKEN",
+                  "message": "리프레시 토큰이 일치하지 않습니다."
+                }
+                """)
+            }))
+    })
     @PostMapping("/refresh")
     public UserLoginResponse refresh(@RequestHeader("Authorization") String refreshToken) {
         return userService.refresh(refreshToken);

--- a/yourtrip/src/main/java/backend/yourtrip/domain/user/dto/request/EmailSendRequest.java
+++ b/yourtrip/src/main/java/backend/yourtrip/domain/user/dto/request/EmailSendRequest.java
@@ -1,0 +1,9 @@
+package backend.yourtrip.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "이메일 인증번호 발송 요청 DTO")
+public record EmailSendRequest(
+    @Schema(description = "회원가입용 이메일", example = "user@example.com")
+    String email
+) {}

--- a/yourtrip/src/main/java/backend/yourtrip/domain/user/dto/request/EmailVerifyRequest.java
+++ b/yourtrip/src/main/java/backend/yourtrip/domain/user/dto/request/EmailVerifyRequest.java
@@ -1,0 +1,12 @@
+package backend.yourtrip.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "이메일 인증번호 검증 요청 DTO")
+public record EmailVerifyRequest(
+    @Schema(description = "회원가입용 이메일", example = "user@example.com")
+    String email,
+
+    @Schema(description = "이메일로 수신한 인증번호 (6자리)", example = "123456")
+    String code
+) {}

--- a/yourtrip/src/main/java/backend/yourtrip/domain/user/dto/request/PasswordSetRequest.java
+++ b/yourtrip/src/main/java/backend/yourtrip/domain/user/dto/request/PasswordSetRequest.java
@@ -1,0 +1,12 @@
+package backend.yourtrip.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "비밀번호 설정 요청 DTO")
+public record PasswordSetRequest(
+    @Schema(description = "회원가입용 이메일", example = "user@example.com")
+    String email,
+
+    @Schema(description = "설정할 비밀번호 (최소 8자 이상, 공백 불가)", example = "Abcd1234!")
+    String password
+) {}

--- a/yourtrip/src/main/java/backend/yourtrip/domain/user/dto/request/ProfileCreateRequest.java
+++ b/yourtrip/src/main/java/backend/yourtrip/domain/user/dto/request/ProfileCreateRequest.java
@@ -1,0 +1,15 @@
+package backend.yourtrip.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "프로필 등록(최종 회원가입) 요청 DTO")
+public record ProfileCreateRequest(
+    @Schema(description = "회원가입용 이메일", example = "user@example.com")
+    String email,
+
+    @Schema(description = "닉네임 (1~20자)", example = "여행러버")
+    String nickname,
+
+    @Schema(description = "프로필 이미지 URL (선택, null일 시 서버 기본 이미지 적용)", example = "https://cdn.example.com/profile.png")
+    String profileImageUrl
+) {}

--- a/yourtrip/src/main/java/backend/yourtrip/domain/user/dto/request/UserLoginRequest.java
+++ b/yourtrip/src/main/java/backend/yourtrip/domain/user/dto/request/UserLoginRequest.java
@@ -1,6 +1,12 @@
 package backend.yourtrip.domain.user.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "이메일 로그인 요청 DTO")
 public record UserLoginRequest(
-        String email,
-        String password
+    @Schema(description = "가입된 이메일", example = "user@example.com")
+    String email,
+
+    @Schema(description = "비밀번호", example = "Abcd1234!")
+    String password
 ) {}

--- a/yourtrip/src/main/java/backend/yourtrip/domain/user/dto/request/UserSignupRequest.java
+++ b/yourtrip/src/main/java/backend/yourtrip/domain/user/dto/request/UserSignupRequest.java
@@ -1,7 +1,0 @@
-package backend.yourtrip.domain.user.dto.request;
-
-public record UserSignupRequest(
-        String email,
-        String password,
-        String nickname
-) {}

--- a/yourtrip/src/main/java/backend/yourtrip/domain/user/dto/response/UserLoginResponse.java
+++ b/yourtrip/src/main/java/backend/yourtrip/domain/user/dto/response/UserLoginResponse.java
@@ -1,7 +1,15 @@
 package backend.yourtrip.domain.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "로그인 및 토큰 재발급 응답 DTO")
 public record UserLoginResponse(
-        Long userId,
-        String nickname,
-        String accessToken
+    @Schema(description = "회원 고유 ID", example = "1")
+    Long userId,
+
+    @Schema(description = "닉네임", example = "여행러버")
+    String nickname,
+
+    @Schema(description = "JWT Access Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+    String accessToken
 ) {}

--- a/yourtrip/src/main/java/backend/yourtrip/domain/user/dto/response/UserSignupResponse.java
+++ b/yourtrip/src/main/java/backend/yourtrip/domain/user/dto/response/UserSignupResponse.java
@@ -1,8 +1,22 @@
 package backend.yourtrip.domain.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "최종 회원가입 완료 응답 DTO")
 public record UserSignupResponse(
-        Long userId,
-        String email,
-        String nickname,
-        String createdAt
+    @Schema(description = "회원 고유 ID", example = "1")
+    Long userId,
+
+    @Schema(description = "이메일", example = "user@example.com")
+    String email,
+
+    @Schema(description = "닉네임", example = "여행러버")
+    String nickname,
+
+    @Schema(description = "프로필 이미지 URL (기본 이미지 또는 사용자가 업로드한 URL)",
+        example = "https://cdn.example.com/profile/default.png")
+    String profileImageUrl,
+
+    @Schema(description = "가입 일시", example = "2025-11-11T10:00:00")
+    String createdAt
 ) {}

--- a/yourtrip/src/main/java/backend/yourtrip/domain/user/entity/User.java
+++ b/yourtrip/src/main/java/backend/yourtrip/domain/user/entity/User.java
@@ -36,4 +36,6 @@ public class User extends BaseEntity {
     private boolean deleted;
 
     private String refreshToken;
+
+    private boolean emailVerified;
 }

--- a/yourtrip/src/main/java/backend/yourtrip/domain/user/mapper/UserMapper.java
+++ b/yourtrip/src/main/java/backend/yourtrip/domain/user/mapper/UserMapper.java
@@ -1,29 +1,18 @@
 package backend.yourtrip.domain.user.mapper;
 
-import backend.yourtrip.domain.user.dto.request.UserSignupRequest;
 import backend.yourtrip.domain.user.dto.response.UserSignupResponse;
 import backend.yourtrip.domain.user.entity.User;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class UserMapper {
-
-    public static User toEntity(UserSignupRequest request, PasswordEncoder encoder) {
-        return User.builder()
-            .email(request.email())
-            .password(encoder.encode(request.password()))
-            .nickname(request.nickname())
-            .deleted(false)
-            .build();
-    }
-
     public static UserSignupResponse toSignupResponse(User user) {
         return new UserSignupResponse(
             user.getId(),
             user.getEmail(),
             user.getNickname(),
+            user.getProfileImageUrl(),
             user.getCreatedAt().toString()
         );
     }

--- a/yourtrip/src/main/java/backend/yourtrip/domain/user/service/UserService.java
+++ b/yourtrip/src/main/java/backend/yourtrip/domain/user/service/UserService.java
@@ -1,14 +1,18 @@
 package backend.yourtrip.domain.user.service;
 
-import backend.yourtrip.domain.user.dto.request.UserLoginRequest;
-import backend.yourtrip.domain.user.dto.request.UserSignupRequest;
-import backend.yourtrip.domain.user.dto.response.UserLoginResponse;
-import backend.yourtrip.domain.user.dto.response.UserSignupResponse;
+import backend.yourtrip.domain.user.dto.request.*;
+import backend.yourtrip.domain.user.dto.response.*;
 import backend.yourtrip.domain.user.entity.User;
 
 public interface UserService {
 
-    UserSignupResponse signup(UserSignupRequest request);
+    void sendVerificationCode(String email);
+
+    void verifyCode(String email, String code);
+
+    void setPassword(String email, String password);
+
+    UserSignupResponse completeSignup(ProfileCreateRequest request);
 
     UserLoginResponse login(UserLoginRequest request);
 

--- a/yourtrip/src/main/java/backend/yourtrip/global/config/SecurityConfig.java
+++ b/yourtrip/src/main/java/backend/yourtrip/global/config/SecurityConfig.java
@@ -35,8 +35,12 @@ public class SecurityConfig {
                 session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(
-                    "/api/users/signup",
+                    "/api/users/email/send",
+                    "/api/users/email/verify",
+                    "/api/users/password",
+                    "/api/users/profile",
                     "/api/users/login",
+                    "/api/users/refresh",
                     "/swagger-ui/**",
                     "/v3/api-docs/**"
                 ).permitAll()

--- a/yourtrip/src/main/java/backend/yourtrip/global/exception/errorCode/MailErrorCode.java
+++ b/yourtrip/src/main/java/backend/yourtrip/global/exception/errorCode/MailErrorCode.java
@@ -1,0 +1,16 @@
+package backend.yourtrip.global.exception.errorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MailErrorCode implements ErrorCode {
+
+    MAIL_SEND_FAILED("이메일 전송에 실패했습니다. 잠시 후 다시 시도해주세요.", HttpStatus.INTERNAL_SERVER_ERROR),
+    INVALID_MAIL_ADDRESS("잘못된 이메일 주소입니다.", HttpStatus.BAD_REQUEST);
+
+    private final String message;
+    private final HttpStatus status;
+}

--- a/yourtrip/src/main/java/backend/yourtrip/global/exception/errorCode/UserErrorCode.java
+++ b/yourtrip/src/main/java/backend/yourtrip/global/exception/errorCode/UserErrorCode.java
@@ -10,7 +10,11 @@ public enum UserErrorCode implements ErrorCode {
 
     EMAIL_ALREADY_EXIST("이미 가입된 이메일입니다.", HttpStatus.BAD_REQUEST),
     EMAIL_NOT_FOUND("존재하지 않는 이메일입니다.", HttpStatus.BAD_REQUEST),
+    EMAIL_NOT_VERIFIED("이메일 인증이 완료되지 않았습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_VERIFICATION_CODE("인증번호가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+    VERIFICATION_CODE_EXPIRED("인증번호가 만료되었습니다.", HttpStatus.BAD_REQUEST),
     NOT_MATCH_PASSWORD("비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_REQUEST_FIELD("요청 필드가 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
     INVALID_REFRESH_TOKEN("유효하지 않은 리프레시 토큰입니다.", HttpStatus.BAD_REQUEST),
     USER_NOT_FOUND("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     NOT_MATCH_REFRESH_TOKEN("리프레시 토큰이 일치하지 않습니다.", HttpStatus.BAD_REQUEST);

--- a/yourtrip/src/main/java/backend/yourtrip/global/jwt/JwtTokenProvider.java
+++ b/yourtrip/src/main/java/backend/yourtrip/global/jwt/JwtTokenProvider.java
@@ -28,23 +28,27 @@ public class JwtTokenProvider {
         return generateToken(userId, email, REFRESH_TOKEN_VALIDITY, "refresh");
     }
 
-    public String generateToken(Long userId, String email, long validity, String type) {
+    private String generateToken(Long userId, String email, long validity, String type) {
         Date now = new Date();
         Date expiry = new Date(now.getTime() + validity);
 
         return Jwts.builder()
-                .setSubject(String.valueOf(userId))
-                .claim("email", email)
-                .claim("typ", type)
-                .setIssuedAt(now)
-                .setExpiration(expiry)
-                .signWith(key, SignatureAlgorithm.HS256)
-                .compact();
+            .setSubject(String.valueOf(userId))
+            .claim("email", email)
+            .claim("typ", type)
+            .setIssuedAt(now)
+            .setExpiration(expiry)
+            .signWith(key, SignatureAlgorithm.HS256)
+            .compact();
     }
 
     public Long getUserId(String token) {
-        Claims claims = parseClaims(token);
-        return Long.parseLong(claims.getSubject());
+        return Long.parseLong(parseClaims(token).getSubject());
+    }
+
+    public String getTokenType(String token) {
+        Object typ = parseClaims(token).get("typ");
+        return typ != null ? typ.toString() : "";
     }
 
     public boolean validateToken(String token) {
@@ -58,9 +62,9 @@ public class JwtTokenProvider {
 
     private Claims parseClaims(String token) {
         return Jwts.parserBuilder()
-                .setSigningKey(key)
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
+            .setSigningKey(key)
+            .build()
+            .parseClaimsJws(token)
+            .getBody();
     }
 }

--- a/yourtrip/src/main/java/backend/yourtrip/global/mail/entity/MailLog.java
+++ b/yourtrip/src/main/java/backend/yourtrip/global/mail/entity/MailLog.java
@@ -1,0 +1,33 @@
+package backend.yourtrip.global.mail.entity;
+
+import backend.yourtrip.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+@Table(name = "mail_logs")
+public class MailLog extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String recipient;
+
+    @Column(nullable = false)
+    private String subject;
+
+    @Column(length = 10)
+    private String status;
+
+    @Column(length = 255)
+    private String errorMessage;
+
+    @Column(nullable = false)
+    private int retryCount;
+}

--- a/yourtrip/src/main/java/backend/yourtrip/global/mail/repository/MailLogRepository.java
+++ b/yourtrip/src/main/java/backend/yourtrip/global/mail/repository/MailLogRepository.java
@@ -1,0 +1,7 @@
+package backend.yourtrip.global.mail.repository;
+
+import backend.yourtrip.global.mail.entity.MailLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MailLogRepository extends JpaRepository<MailLog, Long> {
+}

--- a/yourtrip/src/main/java/backend/yourtrip/global/mail/service/MailService.java
+++ b/yourtrip/src/main/java/backend/yourtrip/global/mail/service/MailService.java
@@ -1,0 +1,76 @@
+package backend.yourtrip.global.mail.service;
+
+import backend.yourtrip.global.exception.BusinessException;
+import backend.yourtrip.global.exception.errorCode.MailErrorCode;
+import backend.yourtrip.global.mail.entity.MailLog;
+import backend.yourtrip.global.mail.repository.MailLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+
+    private final JavaMailSender mailSender;
+    private final MailLogRepository mailLogRepository;
+
+    private static final int MAX_RETRY = 3;
+
+    @Transactional
+    public void sendVerificationMail(String to, String code) {
+        String subject = "[너의 여행은] 이메일 인증번호 안내";
+        String body = """
+                안녕하세요!
+                '너의 여행은' 회원가입 인증번호를 안내드립니다.
+
+                인증번호: %s
+
+                본 메일은 5분간 유효합니다.
+                감사합니다 :)
+                """.formatted(code);
+
+        sendMailWithLogging(to, subject, body, 0);
+    }
+
+    private void sendMailWithLogging(String to, String subject, String text, int attempt) {
+        MailLog.MailLogBuilder logBuilder = MailLog.builder()
+            .recipient(to)
+            .subject(subject)
+            .retryCount(attempt);
+
+        try {
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setTo(to);
+            message.setSubject(subject);
+            message.setText(text);
+            message.setFrom("너의 여행은 <th2194@gmail.com>");
+            mailSender.send(message);
+
+            logBuilder.status("SUCCESS");
+            System.out.println("[메일 전송 성공] " + to);
+
+        } catch (MailSendException e) {
+            logBuilder.status("FAILED").errorMessage(e.getMessage());
+            System.err.println("[메일 전송 실패] " + to + " → " + e.getMessage());
+
+            // 재시도 조건
+            if (attempt < MAX_RETRY) {
+                System.out.println("[재시도 진행] " + (attempt + 1) + "회차");
+                sendMailWithLogging(to, subject, text, attempt + 1);
+            } else {
+                throw new BusinessException(MailErrorCode.MAIL_SEND_FAILED);
+            }
+
+        } catch (Exception e) {
+            logBuilder.status("FAILED").errorMessage(e.getMessage());
+            throw new BusinessException(MailErrorCode.MAIL_SEND_FAILED);
+
+        } finally {
+            mailLogRepository.save(logBuilder.build());
+        }
+    }
+}

--- a/yourtrip/src/main/resources/application.yml
+++ b/yourtrip/src/main/resources/application.yml
@@ -14,6 +14,18 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
     show-sql: true
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_EMAIL}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
 jwt:
   secret: ${JWT_SECRET}
 


### PR DESCRIPTION
# 🔥 Pull Request

## ✅ 작업 내용
- 기존 `/api/users/signup` 단일 API를 단계별 구조로 분리  
- 이메일 인증(발송/검증) 및 비밀번호 설정, 프로필 등록 단계 구현  
- MailService 도입 및 전송 로그(mail_logs) 테이블 추가  

## 📌 관련 이슈
closed #20