### PR TITLE
feat: Terraform으로 AWS S3 인프라 구축

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,10 @@ CLAUDE.md
 .claude/
 .env
 
+# 로컬 개발용 시드 데이터 (사용자/코스/일정/장소 샘플). .worktreeinclude가
+# gitignore된 파일로 전제하고 복사 대상에 포함하고 있으나 규칙이 누락돼 있어 추가.
+src/main/resources/data.sql
+
 ### Terraform ###
 terraform/.terraform/
 terraform/*.tfstate

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,19 @@ out/
 CLAUDE.md
 .claude/
 .env
+
+### Terraform ###
+terraform/.terraform/
+terraform/*.tfstate
+terraform/*.tfstate.*
+terraform/*.tfvars
+terraform/*.tfplan
+terraform/tfplan
+terraform/crash.log
+terraform/crash.*.log
+terraform/override.tf
+terraform/override.tf.json
+terraform/*_override.tf
+terraform/*_override.tf.json
+terraform/.terraformrc
+terraform/terraform.rc

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.60"
+  hashes = [
+    "h1:H3mU/7URhP0uCRGK8jeQRKxx2XFzEqLiOq/L2Bbiaxs=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,82 @@
+# Terraform — AWS S3 인프라
+
+이 디렉토리는 애플리케이션(`S3Config.java`, `S3Service.java`)이 사용하는 AWS S3 버킷과,
+그 버킷에 접근하는 전용 IAM 사용자를 Terraform으로 관리한다.
+
+## 사전 준비
+
+Terraform CLI를 실행하는 주체(관리자 자격증명)와, Terraform이 **생성하는** 앱 전용 IAM
+사용자 자격증명은 서로 다르다.
+
+- 전자는 로컬 `~/.aws/credentials`의 AWS CLI 프로필 또는 `AWS_PROFILE`/`AWS_ACCESS_KEY_ID` 등
+  환경변수로 Terraform CLI에 제공한다. 버킷/IAM 리소스를 만들 수 있는 권한이 있는
+  IAM 사용자(또는 Role)여야 한다. 이 자격증명은 이 저장소 어디에도 들어오지 않는다.
+- 후자(`aws_iam_user.app`)는 이번 `apply`로 새로 발급되며, 애플리케이션이 `.env`를 통해
+  런타임에 사용하는 것이다. 아래 3번 절차에서 다룬다.
+
+## 실행 절차
+
+```bash
+terraform init
+terraform plan -out=tfplan   # 변경 사항을 먼저 파일로 저장해 리뷰한다
+terraform apply tfplan
+```
+
+`plan` 결과를 파일로 저장한 뒤 리뷰하고 나서 `apply`하는 2단계 흐름을 쓰는 이유:
+버킷 이름 오타나 리전 불일치 같은 실수를 apply가 실제로 리소스를 만들기 전에
+미리 걸러내기 위함이다.
+
+값은 `terraform.tfvars.example`을 복사해 `terraform.tfvars`로 만든 뒤 채운다
+(`terraform.tfvars`는 git에 커밋하지 않는다 — `.gitignore` 참고).
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+# terraform.tfvars에서 bucket_name을 전역 고유한 값으로 채운다
+```
+
+`bucket_name`은 AWS 전체에서 유일해야 한다. 첫 `apply`에서 `BucketAlreadyExists`가 나면
+`terraform.tfvars`의 `bucket_name`을 바꿔 다시 시도한다.
+
+## apply 이후 `.env` 반영
+
+```bash
+terraform output -raw s3_bucket_name
+terraform output -raw iam_user_access_key_id
+terraform output -raw iam_user_secret_access_key
+```
+
+위 세 값을 각각 `.env`의 `S3_BUCKET`, `AWS_ACCESS_KEY`, `AWS_SECRET_KEY`에 수동으로 붙여넣는다.
+(`.env.example` 참고)
+
+## 트레이드오프 — 알고 있어야 할 것
+
+이 구성은 Terraform state를 **로컬 파일**로 관리하기로 결정했다(remote backend 없음,
+1인/소규모 포트폴리오 프로젝트 특성상 채택). 이에 따른 트레이드오프:
+
+- `aws_iam_access_key.app`이 발급하는 IAM secret access key가 로컬 `terraform.tfstate`
+  파일에 **평문으로 저장**된다. `terraform.tfstate*`는 `.gitignore`로 git 추적에서
+  제외되지만, 로컬 디스크에는 평문으로 남아있다는 점을 인지하고 있어야 한다.
+- 포트폴리오를 공개 시연한 뒤에는 `terraform taint aws_iam_access_key.app` 실행 후
+  다시 `apply`해 access key를 재발급(rotate)하는 것을 권장한다.
+- `terraform output -raw iam_user_secret_access_key`로 시크릿을 터미널에 출력하면
+  쉘 히스토리/스크롤백에도 남을 수 있으므로, 값을 `.env`에 옮긴 뒤에는 터미널을
+  정리하는 것을 권장한다.
+
+## 버저닝을 켜지 않은 이유
+
+`aws_s3_bucket_versioning`을 `Disabled`로 명시했다. `S3Service.deleteFile()`은 사용자의
+명시적 삭제 요청에 대응하는데, 버저닝을 켜면 delete가 실제로는 delete marker만 추가하고
+이전 버전이 스토리지에 남아 "삭제하면 진짜 지워진다"는 앱의 기대 동작과 어긋나고 비용만
+쌓인다. 또한 업로드 키가 `uploads/{date}/{uuid}.{ext}`로 UUID 기반이라 동일 키 덮어쓰기
+충돌 가능성이 사실상 없어, 버저닝이 방어하는 시나리오 자체가 희박하다.
+
+## 파괴(destroy)
+
+```bash
+terraform destroy
+```
+
+`bucket_force_destroy = false`(기본값)인 상태에서 버킷에 오브젝트가 남아있으면
+`destroy`가 실패한다. 이는 실수로 데이터가 함께 삭제되는 것을 막는 의도된
+안전장치이며, 정말로 버킷을 비우고 지우고 싶다면 `terraform.tfvars`에서
+`bucket_force_destroy = true`로 바꾼 뒤 다시 `apply` → `destroy`한다.

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,0 +1,52 @@
+# 애플리케이션(S3Config.java)이 AwsBasicCredentials로 사용할 프로그래매틱 전용 IAM 사용자.
+# 콘솔 로그인 프로필(aws_iam_user_login_profile)은 만들지 않는다 — API 호출에만 쓰이는
+# 계정에 콘솔 비밀번호를 발급하는 것은 불필요한 공격 표면이다.
+resource "aws_iam_user" "app" {
+  name = var.iam_user_name
+  path = "/service-accounts/"
+}
+
+# S3Config.java가 정적 자격증명(access key/secret key) 방식을 전제하고 있으므로
+# 그에 맞춰 access key를 발급한다.
+resource "aws_iam_access_key" "app" {
+  user = aws_iam_user.app.name
+}
+
+# S3Service.java가 실제로 호출하는 SDK 메서드는 putObject / deleteObject /
+# (presigner를 통한) getObject 세 가지뿐이다. 이 세 개만 허용한다.
+data "aws_iam_policy_document" "app_s3_access" {
+  statement {
+    sid    = "AllowObjectReadWriteDelete"
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:DeleteObject",
+    ]
+    resources = ["${aws_s3_bucket.media.arn}/*"]
+  }
+
+  # 코드 전체에 ListObjectsV2 등 리스트 계열 API 호출이 없어 기본은 비활성.
+  # 관리자용 파일 목록 조회 기능이 추가되면 var.grant_list_bucket = true로 전환한다.
+  # ListBucket은 객체 ARN이 아니라 버킷 ARN을 대상으로 해야 한다 — 이 둘을 혼용하면
+  # ListBucket이 항상 AccessDenied가 나는 흔한 실수이므로 별도 statement로 분리한다.
+  dynamic "statement" {
+    for_each = var.grant_list_bucket ? [1] : []
+    content {
+      sid       = "AllowListBucket"
+      effect    = "Allow"
+      actions   = ["s3:ListBucket"]
+      resources = [aws_s3_bucket.media.arn]
+    }
+  }
+}
+
+resource "aws_iam_policy" "app_s3_access" {
+  name   = "${var.iam_user_name}-s3-access"
+  policy = data.aws_iam_policy_document.app_s3_access.json
+}
+
+resource "aws_iam_user_policy_attachment" "app_s3_access" {
+  user       = aws_iam_user.app.name
+  policy_arn = aws_iam_policy.app_s3_access.arn
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,20 @@
+output "s3_bucket_name" {
+  description = ".env의 S3_BUCKET에 채워 넣을 값"
+  value       = aws_s3_bucket.media.bucket
+}
+
+output "s3_bucket_arn" {
+  description = "생성된 버킷의 ARN (참고/디버깅용)"
+  value       = aws_s3_bucket.media.arn
+}
+
+output "iam_user_access_key_id" {
+  description = ".env의 AWS_ACCESS_KEY에 채워 넣을 값"
+  value       = aws_iam_access_key.app.id
+}
+
+output "iam_user_secret_access_key" {
+  description = ".env의 AWS_SECRET_KEY에 채워 넣을 값. 평문 시크릿이므로 sensitive 처리."
+  value       = aws_iam_access_key.app.secret
+  sensitive   = true
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project   = "yourtrip"
+      ManagedBy = "terraform"
+    }
+  }
+}

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,0 +1,51 @@
+# 애플리케이션(S3Service.java)이 업로드/조회/삭제하는 미디어(프로필 이미지, 코스 장소 사진,
+# 피드 미디어, 코스 썸네일)를 저장하는 단일 버킷. 모든 도메인이 이 버킷 하나를 공유하며
+# uploads/{yyyy-MM-dd}/{uuid}.{ext} 키로 날짜별 prefix만 구분한다(버킷 분리 불필요).
+resource "aws_s3_bucket" "media" {
+  bucket = var.bucket_name
+
+  # 방금 만든 버킷을 실수로 destroy했을 때 데이터를 함께 날리지 않도록 기본은 차단한다.
+  # 재현/삭제가 필요할 때는 var.bucket_force_destroy로 명시적으로 override한다.
+  force_destroy = var.bucket_force_destroy
+}
+
+# S3Service.getPresignedUrl()이 GET presigned URL(15분 TTL)만 발급하고, 버킷 정책이나
+# 오브젝트 ACL을 public으로 여는 코드가 전혀 없다. 즉 버킷이 private이어도 앱 동작에
+# 지장이 없으므로 퍼블릭 접근을 4개 항목 모두 차단한다.
+resource "aws_s3_bucket_public_access_block" "media" {
+  bucket = aws_s3_bucket.media.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# S3Service.java 93~94행 주석("SSE-S3 기본 암호화 켰으면 생략 가능")이 버킷 레벨
+# 기본 암호화를 전제하고 있으므로, 코드 의도와 일치시키기 위해 SSE-S3(AES256)를 켠다.
+# SSE-KMS를 쓰지 않는 이유: 코드 주석이 명시한 알고리즘(AES256)과 일치시키기 위함이며,
+# 이 규모 프로젝트에서 KMS 키 관리 비용/복잡도를 추가할 근거가 없다.
+resource "aws_s3_bucket_server_side_encryption_configuration" "media" {
+  bucket = aws_s3_bucket.media.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# AWS 기본값과 동일(Disabled)하지만 의도적으로 명시한다: "고민 없이 방치된 기본값"과
+# "검토 후 끄기로 결정한 값"을 코드만 보고 구분하기 위함이다.
+# - S3Service.deleteFile()은 사용자의 명시적 삭제 요청에 대응한다. 버저닝을 켜면 delete는
+#   delete marker만 추가하고 이전 버전이 스토리지에 남아 "삭제하면 진짜 지워진다"는 앱의
+#   기대 동작과 어긋나고 비용만 쌓인다.
+# - 업로드 키가 uploads/{date}/{uuid}.{ext}로 UUID 기반이라 동일 키 덮어쓰기 충돌
+#   가능성이 사실상 없어, 버저닝이 방어하는 "덮어쓰기 실수" 시나리오 자체가 희박하다.
+resource "aws_s3_bucket_versioning" "media" {
+  bucket = aws_s3_bucket.media.id
+
+  versioning_configuration {
+    status = "Disabled"
+  }
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,8 @@
+# terraform/terraform.tfvars 로 복사한 뒤 실제 값을 채워 사용한다.
+# (terraform.tfvars는 git에 커밋하지 않는다)
+
+aws_region = "ap-northeast-2" # application.yml의 s3.region 하드코딩 값과 반드시 일치시킬 것
+bucket_name = ""               # 전역 고유해야 함 (예: yourtrip-media-<본인식별자>)
+iam_user_name = "yourtrip-s3-app-user"
+grant_list_bucket = false
+bucket_force_destroy = false

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,28 @@
+variable "aws_region" {
+  description = "S3 버킷을 생성할 리전. application.yml의 s3.region 하드코딩 값(ap-northeast-2)과 반드시 일치해야 한다."
+  type        = string
+  default     = "ap-northeast-2"
+}
+
+variable "bucket_name" {
+  description = "S3 버킷 이름. 전역적으로 고유해야 하므로 기본값을 두지 않고 tfvars에서 반드시 지정하도록 강제한다."
+  type        = string
+}
+
+variable "iam_user_name" {
+  description = "애플리케이션이 S3 접근에 사용할 프로그래매틱 전용 IAM 사용자 이름."
+  type        = string
+  default     = "yourtrip-s3-app-user"
+}
+
+variable "grant_list_bucket" {
+  description = "S3Service.java는 현재 ListBucket 계열 API를 호출하지 않는다. 최소 권한 원칙에 따라 기본은 false이며, 추후 파일 목록 조회 기능이 추가되면 true로 전환한다."
+  type        = bool
+  default     = false
+}
+
+variable "bucket_force_destroy" {
+  description = "true로 두면 버킷에 오브젝트가 남아있어도 terraform destroy가 강제로 삭제한다. 실수로 인한 데이터 유실을 막기 위해 기본값은 false."
+  type        = bool
+  default     = false
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,14 @@
+# 이 구성이 검증된 Terraform/Provider 버전 범위를 명시한다.
+# required_version 상한(< 2.0.0)은 2.x에서 발생할 수 있는 breaking change로부터
+# "이 구성은 1.x에서만 검증됐다"는 사실을 명시적으로 선언하기 위함이다.
+terraform {
+  required_version = ">= 1.9.0, < 2.0.0"
+
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      # 마이너 버전 자동 업데이트는 허용하되 메이저 버전(6.x) 자동 승격은 막는다.
+      version = "~> 5.60"
+    }
+  }
+}


### PR DESCRIPTION
## ✅ 작업 내용

### Terraform으로 S3 인프라 구축
- 버킷/IAM 사용자를 AWS 콘솔에서 수동으로 만드는 대신 `terraform apply`로 재현할 수 있다
- `S3Config.java`/`S3Service.java`가 이미 전제하던 인프라 형태(버킷 1개, private, SSE-S3, 정적 IAM 자격증명 기반 접근)를 선언적으로 재현했다
- 실제로 apply까지 진행해 버킷과 IAM 사용자가 생성된 상태이며, 로그인 → 프로필 이미지 업로드 → presigned URL 다운로드 → 삭제까지 앱 레벨에서 직접 검증했다

### 코드 사용 패턴에 맞춘 S3 버킷 보안 설정
- `S3Service`가 presigned GET URL만 사용하고 퍼블릭 접근이 필요 없어, public access block 4개 항목을 모두 차단했다
- 버킷 레벨 SSE-S3(AES256) 기본 암호화를 켜서 코드 주석(`S3Service.java`)이 전제하던 설정과 일치시켰다
- 버저닝은 켜지 않기로 한 결정과 근거(삭제 요청 시 실제로 삭제되길 기대하는 앱 동작, UUID 기반 키라 덮어쓰기 충돌이 희박함)를 코드 주석과 README에 남겼다

### S3 접근용 IAM 최소 권한 구성
- `S3Service.java`가 실제로 호출하는 `PutObject`/`GetObject`/`DeleteObject`만 허용한다
- `ListBucket`은 코드에서 미사용이라 기본 비활성화하고, 필요해지면 변수 하나로 켤 수 있게 스위치만 마련했다
- 콘솔 로그인 없이 프로그래매틱 전용 사용자로 발급해 불필요한 공격 표면을 없앴다

### Terraform 실행 절차 및 트레이드오프 문서화
- `terraform/README.md`에 init/plan/apply 절차와 apply 이후 `.env` 반영 절차를 단계별로 안내했다
- 로컬 state 운영에 따라 IAM secret이 `tfstate`에 평문 저장되는 트레이드오프와 완화책(시연 후 키 재발급 등)을 명시했다

## 📌 관련 이슈
연결된 이슈 없음

## 📚 추가 리팩토링 가능성
- CI 도입 시 `terraform fmt -check`/`terraform validate`를 파이프라인에 포함하면 좋다
- IAM 자격증명 로테이션 절차를 필요 시 자동화할 수 있다
- 향후 EC2/ECS 등 AWS 컴퓨트 위에서 앱이 실행되는 시나리오로 바뀌면 IAM Role(인스턴스 프로파일) 기반 전환이 정적 access key보다 더 안전한 표준 패턴이다