### PR TITLE
feat: 업로드 코스 통합 수정 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/build.gradle
+++ b/build.gradle
@@ -8,12 +8,6 @@ group = 'backend'
 version = '0.0.1-SNAPSHOT'
 description = 'yourtrip'
 
-configurations {
-    compileOnly {
-        extendsFrom annotationProcessor
-    }
-}
-
 repositories {
     mavenCentral()
 }
@@ -52,6 +46,14 @@ dependencies {
     implementation platform('software.amazon.awssdk:bom:2.25.30') // 최신 안정판으로 맞추기
     implementation 'software.amazon.awssdk:s3'
     implementation 'com.google.genai:google-genai:1.28.0'
+}
+
+compileJava {
+    options.annotationProcessorPath = configurations.annotationProcessor
+}
+
+compileTestJava {
+    options.annotationProcessorPath = configurations.testAnnotationProcessor
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -8,12 +8,6 @@ group = 'backend'
 version = '0.0.1-SNAPSHOT'
 description = 'yourtrip'
 
-configurations {
-    compileOnly {
-        extendsFrom annotationProcessor
-    }
-}
-
 repositories {
     mavenCentral()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,15 @@ group = 'backend'
 version = '0.0.1-SNAPSHOT'
 description = 'yourtrip'
 
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+    testCompileOnly {
+        extendsFrom testAnnotationProcessor
+    }
+}
+
 repositories {
     mavenCentral()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,12 @@ group = 'backend'
 version = '0.0.1-SNAPSHOT'
 description = 'yourtrip'
 
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
+
 repositories {
     mavenCentral()
 }

--- a/docs/api-changes/upload-course-update.md
+++ b/docs/api-changes/upload-course-update.md
@@ -1,0 +1,257 @@
+# API 변경사항 — 업로드 코스 통합 수정
+
+> 이 문서는 프론트엔드(Android) 개발자에게 전달하기 위한 API 변경사항 문서입니다. **기존 API에는 영향이 없으며, 업로드 코스를 한 번에 수정할 수 있는 단일 신규 엔드포인트가 추가**되었습니다.
+
+---
+
+## 1. 요약
+
+| 항목 | 내용 |
+|---|---|
+| **변경 종류** | 신규 엔드포인트 추가 (기존 API 변경 없음, Breaking Change 없음) |
+| **엔드포인트** | `PUT /api/upload-courses/{uploadCourseId}` |
+| **Request Type** | `multipart/form-data` |
+| **인증 여부** | **필수** (`Authorization: Bearer <JWT_TOKEN>`, 작성자 본인만 가능) |
+| **대응 화면** | 업로드한 코스 상세 화면 → **코스 수정 화면** |
+
+---
+
+## 2. 엔드포인트 상세
+
+### `PUT /api/upload-courses/{uploadCourseId}`
+
+업로드 코스의 주요 정보(제목, 소개, 위치, 여행 기간, 키워드, 썸네일 이미지, 일차별 일정 및 장소 사진)를 단일 API로 통합 수정합니다.
+
+> [!NOTE]
+> `forkCount`, `viewCount`, `heartCount` 및 PK ID값(`uploadCourseId`, `dayScheduleId`, `placeId`, `placeImageId`) 자체는 절대 변경할 수 없으나, 기존 장소/일정 엔티티를 식별하고 유지·갱신하기 위해 DTO 요청에 해당 PK ID를 포함하여 전달해야 합니다.
+
+---
+
+### 3. Request Parts (`multipart/form-data`)
+
+| Part Name | Content-Type | 필수 여부 | 설명 |
+|---|---|---|---|
+| `request` | `application/json` | **필수** | 수정할 코스 전체 데이터 (`UploadCourseUpdateRequest` JSON) |
+| `thumbnailImage` | `image/*` | 선택 | 신규 썸네일 이미지 파일. **미전달(null) 시 기존 썸네일 이미지가 그대로 유지**됩니다. |
+| `placeImages` | `image/*` (List) | 선택 | 장소에 새로 추가/교체할 이미지 파일 목록. DTO의 `newImageIndex`와 0부터 시작하는 인덱스로 매핑됩니다. |
+
+---
+
+## 4. DTO 스키마 (`request` JSON)
+
+### 4.1 Root: `UploadCourseUpdateRequest`
+
+| 필드명 | 타입 | 필수 여부 | 설명 |
+|---|---|---|---|
+| `title` | string | **필수** | 코스 제목 (비어있을 수 없음) |
+| `introduction` | string | 선택 | 코스 소개글 |
+| `location` | string | 선택 | 대표 여행 위치 (예: `"경주 포석로"`) |
+| `startDate` | string (ISO Date) | **필수** | 여행 시작일 (`"YYYY-MM-DD"`) |
+| `endDate` | string (ISO Date) | **필수** | 여행 종료일 (`"YYYY-MM-DD"`) |
+| `keywords` | Array\<KeywordType\> | 선택 | 코스 태그/키워드 enum 코드 목록 (예: `["WALK", "FOOD"]`) |
+| `daySchedules` | Array\<DayScheduleUpdateRequest\> | 선택 | 일차별 일정 목록 |
+
+---
+
+### 4.2 `DayScheduleUpdateRequest`
+
+| 필드명 | 타입 | 필수 여부 | 설명 |
+|---|---|---|---|
+| `dayScheduleId` | Long | 선택 | **기존 일차 PK**. 기존일정을 수정하는 경우 필수 전달. **신규 생성 시 `null`** |
+| `day` | Integer | **필수** | 몇 일차인지 지정 (1부터 시작) |
+| `places` | Array\<PlaceUpdateRequest\> | 선택 | 해당 일차에 포함된 장소 목록 |
+
+---
+
+### 4.3 `PlaceUpdateRequest`
+
+| 필드명 | 타입 | 필수 여부 | 설명 |
+|---|---|---|---|
+| `placeId` | Long | 선택 | **기존 장소 PK**. 기존 장소를 수정하는 경우 필수 전달. **신규 생성 시 `null`** |
+| `placeName` | string | **필수** | 장소명 |
+| `startTime` | string (ISO Time) | 선택 | 방문 시작 시간 (`"HH:mm"` 또는 `"HH:mm:ss"`) |
+| `memo` | string | 선택 | 장소 메모 |
+| `latitude` | double | **필수** | 위도 |
+| `longitude` | double | **필수** | 경도 |
+| `placeUrl` | string | 선택 | 카카오 지도 장소 URL |
+| `placeLocation` | string | 선택 | 장소 주소 |
+| `placeImages` | Array\<PlaceImageUpdateRequest\> | 선택 | 장소 첨부 사진 목록 |
+
+---
+
+### 4.4 `PlaceImageUpdateRequest`
+
+| 필드명 | 타입 | 필수 여부 | 설명 |
+|---|---|---|---|
+| `placeImageId` | Long | 선택 | **기존 장소 사진 PK**. 기존 사진을 그대로 유지할 때 전달. 신규 사진 첨부 시 `null` |
+| `newImageIndex` | Integer | 선택 | **신규 첨부 사진 인덱스**. `placeImageId`가 `null`일 때 `placeImages` 파일 리스트의 몇 번째 파일(0부터 시작)인지를 지정. 기존 사진 유지 시 `null` |
+
+---
+
+## 5. 엔티티 수정/추가/삭제 매칭 규칙 (중요 ⭐)
+
+프론트엔드에서는 요청 DTO 구성 시 아래 규칙을 반드시 준수해야 합니다.
+
+1. **기존 항목 유지 및 갱신 (ID 전달)**:
+   - DTO에 `dayScheduleId`, `placeId`, `placeImageId` 값을 포함하여 전송하면, 해당 엔티티의 정보가 전달받은 값으로 갱신됩니다.
+2. **신규 항목 추가 (ID = null)**:
+   - `dayScheduleId` 또는 `placeId`를 `null`로 전송하면 신규 일차/장소로 DB에 추가됩니다.
+   - 장소 사진의 경우 `placeImageId: null`로 설정하고 `newImageIndex`에 `placeImages` 파트 파일 리스트에서의 0 기반 인덱스(`0`, `1`, `2`...)를 지정합니다.
+3. **기존 항목 삭제 (ID 누락)**:
+   - 기존 DB에 존재하던 일차, 장소, 사진 ID 중 **이번 수정 DTO 목록에서 빠진 항목은 DB에서 자동으로 삭제** 처리됩니다 (연관된 S3 이미지 파일도 자동 삭제됨).
+
+---
+
+## 6. 요청 예시
+
+### 6.1 `request` JSON 예시 (`application/json`)
+
+```json
+{
+  "title": "경주 인생샷 투어 (수정)",
+  "introduction": "황리단길과 첨성대 야경 코스를 일부분 수정했습니다.",
+  "location": "경주 포석로",
+  "startDate": "2025-03-01",
+  "endDate": "2025-03-02",
+  "keywords": ["WALK", "FOOD", "HEALING"],
+  "daySchedules": [
+    {
+      "dayScheduleId": 100,
+      "day": 1,
+      "places": [
+        {
+          "placeId": 200,
+          "placeName": "황리단길 카페거리",
+          "startTime": "10:30:00",
+          "memo": "카페 골목 산책 및 브런치",
+          "latitude": 35.8375,
+          "longitude": 129.2123,
+          "placeUrl": "http://place.map.kakao.com/26338954",
+          "placeLocation": "경북 경주시 포석로 인근",
+          "placeImages": [
+            {
+              "placeImageId": 500,
+              "newImageIndex": null
+            },
+            {
+              "placeImageId": null,
+              "newImageIndex": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "dayScheduleId": null,
+      "day": 2,
+      "places": [
+        {
+          "placeId": null,
+          "placeName": "불국사",
+          "startTime": "09:00:00",
+          "memo": "아침 산책",
+          "latitude": 35.7901,
+          "longitude": 129.3323,
+          "placeUrl": "http://place.map.kakao.com/123456",
+          "placeLocation": "경북 경주시 불국로 385",
+          "placeImages": [
+            {
+              "placeImageId": null,
+              "newImageIndex": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+## 7. 응답 스키마 (`200 OK`)
+
+기존 `GET /api/upload-courses/{uploadCourseId}` (상세 조회) 응답 스키마(`UploadCourseDetailResponse`)와 **완전히 동일**합니다.
+
+```json
+{
+  "uploadCourseId": 1,
+  "title": "경주 인생샷 투어 (수정)",
+  "introduction": "황리단길과 첨성대 야경 코스를 일부분 수정했습니다.",
+  "location": "경주 포석로",
+  "thumbnailImageUrl": "https://s3.amazonaws.com/yourbucket/thumbnail.png?X-Amz-...",
+  "startDate": "2025-03-01",
+  "endDate": "2025-03-02",
+  "forkCount": 12,
+  "keywords": ["뚜벅이", "맛집탐방", "힐링"],
+  "daySchedules": [
+    {
+      "dayScheduleId": 100,
+      "day": 1,
+      "places": [
+        {
+          "placeId": 200,
+          "placeName": "황리단길 카페거리",
+          "startTime": "10:30:00",
+          "memo": "카페 골목 산책 및 브런치",
+          "latitude": 35.8375,
+          "longitude": 129.2123,
+          "placeUrl": "http://place.map.kakao.com/26338954",
+          "placeLocation": "경북 경주시 포석로 인근",
+          "placeImages": [
+            {
+              "placeImageId": 500,
+              "imageUrl": "https://s3.amazonaws.com/yourbucket/place1.png?X-Amz-..."
+            },
+            {
+              "placeImageId": 501,
+              "imageUrl": "https://s3.amazonaws.com/yourbucket/place2.png?X-Amz-..."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+## 8. 에러 응답
+
+| 상황 | HTTP 상태 | `code` | `message` |
+|---|---|---|---|
+| 본인 작성 코스가 아닌 경우 수정 시도 | **403 FORBIDDEN** | `NOT_OWNED_UPLOAD_COURSE` | 본인이 업로드한 코스만 수정할 수 있습니다. |
+| 존재하지 않는 `uploadCourseId` | **404 NOT FOUND** | `UPLOAD_COURSE_NOT_FOUND` | 업로드 코스를 찾을 수 없습니다. |
+| 필수 필드(`title`, `startDate` 등) 누락 | **400 BAD REQUEST** | `MethodArgumentNotValidException` | 유효성 검사 실패 메시지 |
+
+### 에러 응답 예시 (403 FORBIDDEN)
+```json
+{
+  "timestamp": "2026-08-01T15:00:00.000000",
+  "code": "NOT_OWNED_UPLOAD_COURSE",
+  "message": "본인이 업로드한 코스만 수정할 수 있습니다."
+}
+```
+
+---
+
+## 9. 프론트엔드(Retrofit/OkHttp) 연동 팁
+
+Retrofit 인터페이스 구성 예시:
+
+```kotlin
+interface UploadCourseApi {
+    @Multipart
+    @PUT("/api/upload-courses/{uploadCourseId}")
+    suspend fun updateUploadCourse(
+        @Path("uploadCourseId") uploadCourseId: Long,
+        @Part("request") request: RequestBody, // MediaType: application/json
+        @Part thumbnailImage: MultipartBody.Part? = null,
+        @Part placeImages: List<MultipartBody.Part>? = null
+    ): Response<UploadCourseDetailResponse>
+}
+```
+
+- `request` 파트는 `RequestBody.create("application/json".toMediaTypeOrNull(), jsonString)` 형태로 전달해주시면 됩니다.
+- 썸네일을 새로 바꾸지 않을 때는 `thumbnailImage` 파트를 아예 보내지 않거나 `null`로 보냅니다.

--- a/src/main/java/backend/yourtrip/domain/mycourse/entity/place/Place.java
+++ b/src/main/java/backend/yourtrip/domain/mycourse/entity/place/Place.java
@@ -88,6 +88,9 @@ public class Place extends BaseEntity {
         this.placeLocation = placeLocation;
         this.placeUrl = placeUrl;
         this.latitude = latitude;
+        this.longitude = longitude;
+    }
+
     public void updatePlaceInfo(String placeName, LocalTime startTime, String memo,
         double latitude, double longitude, String placeUrl, String placeLocation) {
         this.placeName = placeName;

--- a/src/main/java/backend/yourtrip/domain/mycourse/entity/place/Place.java
+++ b/src/main/java/backend/yourtrip/domain/mycourse/entity/place/Place.java
@@ -88,6 +88,14 @@ public class Place extends BaseEntity {
         this.placeLocation = placeLocation;
         this.placeUrl = placeUrl;
         this.latitude = latitude;
+    public void updatePlaceInfo(String placeName, LocalTime startTime, String memo,
+        double latitude, double longitude, String placeUrl, String placeLocation) {
+        this.placeName = placeName;
+        this.startTime = startTime;
+        this.memo = memo;
+        this.latitude = latitude;
         this.longitude = longitude;
+        this.placeUrl = placeUrl;
+        this.placeLocation = placeLocation;
     }
 }

--- a/src/main/java/backend/yourtrip/domain/mycourse/entity/travelCourse/TravelCourse.java
+++ b/src/main/java/backend/yourtrip/domain/mycourse/entity/travelCourse/TravelCourse.java
@@ -83,4 +83,11 @@ public class TravelCourse extends BaseEntity {
     public void markAsUploaded() {
         this.uploaded = true;
     }
+
+    public void updateCourseInfo(String title, String location, LocalDate startDate, LocalDate endDate) {
+        this.title = title;
+        this.location = location;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
 }

--- a/src/main/java/backend/yourtrip/domain/mycourse/entity/travelCourse/TravelCourse.java
+++ b/src/main/java/backend/yourtrip/domain/mycourse/entity/travelCourse/TravelCourse.java
@@ -64,7 +64,7 @@ public class TravelCourse extends BaseEntity {
     /** 업로드 코스용 사본이 이미 만들어졌는지 여부(중복 업로드 방지) */
     private boolean uploaded;
 
-    @OneToMany(mappedBy = "course")
+    @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("day ASC")
     private List<DaySchedule> daySchedules;
 

--- a/src/main/java/backend/yourtrip/domain/uploadcourse/controller/UploadCourseController.java
+++ b/src/main/java/backend/yourtrip/domain/uploadcourse/controller/UploadCourseController.java
@@ -1,6 +1,7 @@
 package backend.yourtrip.domain.uploadcourse.controller;
 
 import backend.yourtrip.domain.uploadcourse.dto.request.UploadCourseCreateRequest;
+import backend.yourtrip.domain.uploadcourse.dto.request.UploadCourseUpdateRequest;
 import backend.yourtrip.domain.uploadcourse.dto.response.CourseKeywordListResponse;
 import backend.yourtrip.domain.uploadcourse.dto.response.UploadCourseCreateResponse;
 import backend.yourtrip.domain.uploadcourse.dto.response.UploadCourseDetailResponse;
@@ -17,6 +18,7 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -93,6 +95,19 @@ public class UploadCourseController implements UploadCourseControllerSpec {
         @RequestParam(name = "theme", required = false) KeywordType theme
     ) {
         return uploadCourseService.getPopularCourses(theme);
+    }
+
+    // ==========================
+    //  업로드 코스 통합 수정
+    // ==========================
+    @Override
+    @PutMapping(value = "/{uploadCourseId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public UploadCourseDetailResponse updateUploadCourse(
+        @PathVariable Long uploadCourseId,
+        @RequestPart(value = "thumbnailImage", required = false) MultipartFile thumbnailImage,
+        @RequestPart(value = "placeImages", required = false) List<MultipartFile> placeImages,
+        @Valid @RequestPart(value = "request") UploadCourseUpdateRequest request) {
+        return uploadCourseService.updateUploadCourse(uploadCourseId, request, thumbnailImage, placeImages);
     }
 
 }

--- a/src/main/java/backend/yourtrip/domain/uploadcourse/controller/UploadCourseControllerSpec.java
+++ b/src/main/java/backend/yourtrip/domain/uploadcourse/controller/UploadCourseControllerSpec.java
@@ -1,6 +1,7 @@
 package backend.yourtrip.domain.uploadcourse.controller;
 
 import backend.yourtrip.domain.uploadcourse.dto.request.UploadCourseCreateRequest;
+import backend.yourtrip.domain.uploadcourse.dto.request.UploadCourseUpdateRequest;
 import backend.yourtrip.domain.uploadcourse.dto.response.CourseKeywordListResponse;
 import backend.yourtrip.domain.uploadcourse.dto.response.UploadCourseCreateResponse;
 import backend.yourtrip.domain.uploadcourse.dto.response.UploadCourseDetailResponse;
@@ -509,5 +510,47 @@ public interface UploadCourseControllerSpec {
     })
     UploadCourseListResponse getPopularCourses(
         @Parameter(description = "mood 카테고리 키워드 코드", example = "FOOD") KeywordType theme);
+
+    // ==========================
+    //  업로드 코스 통합 수정
+    // ==========================
+    @Operation(
+        summary = "업로드 코스 통합 수정",
+        description = """
+            업로드 코스의 정보(제목, 소개, 위치, 시작/종료일, 썸네일 이미지, 키워드, 일차별 일정 및 장소 사진)를 단일 API로 통합 수정합니다.
+
+            ### 제약조건
+            - 경로 변수: uploadCourseId (수정할 업로드 코스 PK)
+            - 작성자 본인만 수정 가능 (타인의 코스 수정 시 403 FORBIDDEN 반환)
+            - thumbnailImage: 선택사항. 전달 시 기존 썸네일을 삭제하고 신규 썸네일로 교체합니다. 미전달 시 기존 썸네일이 유지됩니다.
+            - placeImages: 선택사항. 장소별 신규 첨부 사진 파일 목록 (0부터 시작하는 인덱스로 DTO의 newImageIndex와 매핑)
+            - DTO 내 기존 dayScheduleId, placeId, placeImageId를 포함하여 전달하면 해당 엔티티를 갱신합니다. 포함되지 않은 기존 엔티티는 삭제 처리되며, id가 null인 신규 항목은 새로 추가됩니다.
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "업로드 코스 수정 성공",
+            content = @Content(schema = @Schema(implementation = UploadCourseDetailResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "403",
+            description = "본인이 업로드한 코스가 아닌 경우",
+            content = @Content(mediaType = "application/json")
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "업로드 코스를 찾을 수 없는 경우",
+            content = @Content(mediaType = "application/json")
+        )
+    })
+    UploadCourseDetailResponse updateUploadCourse(
+        @Schema(example = "1") Long uploadCourseId,
+        MultipartFile thumbnailImage,
+        List<MultipartFile> placeImages,
+        @Parameter(content = @Content(
+            mediaType = MediaType.APPLICATION_JSON_VALUE,
+            schema = @Schema(implementation = UploadCourseUpdateRequest.class)
+        )) UploadCourseUpdateRequest request);
 
 }

--- a/src/main/java/backend/yourtrip/domain/uploadcourse/dto/request/DayScheduleUpdateRequest.java
+++ b/src/main/java/backend/yourtrip/domain/uploadcourse/dto/request/DayScheduleUpdateRequest.java
@@ -1,0 +1,23 @@
+package backend.yourtrip.domain.uploadcourse.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record DayScheduleUpdateRequest(
+    @Schema(description = "일차 ID (기존 일차 수정 시 전달, 신규 일차 추가 시 null)", example = "1")
+    Long dayScheduleId,
+
+    @Schema(description = "일차 (n일차)", example = "1")
+    int day,
+
+    @Schema(description = "해당 일차의 장소 목록")
+    @NotNull(message = "장소 목록은 필수입니다.")
+    @Valid
+    List<PlaceUpdateRequest> places
+) {
+
+}

--- a/src/main/java/backend/yourtrip/domain/uploadcourse/dto/request/PlaceImageUpdateRequest.java
+++ b/src/main/java/backend/yourtrip/domain/uploadcourse/dto/request/PlaceImageUpdateRequest.java
@@ -1,0 +1,15 @@
+package backend.yourtrip.domain.uploadcourse.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record PlaceImageUpdateRequest(
+    @Schema(description = "기존 장소 사진 ID (기존 사진 유지 시 전달)", example = "1")
+    Long placeImageId,
+
+    @Schema(description = "신규 장소 사진 파일 인덱스 (placeImages 멀티파트 파일 배열 내 0부터 시작하는 인덱스)", example = "0")
+    Integer newImageIndex
+) {
+
+}

--- a/src/main/java/backend/yourtrip/domain/uploadcourse/dto/request/PlaceUpdateRequest.java
+++ b/src/main/java/backend/yourtrip/domain/uploadcourse/dto/request/PlaceUpdateRequest.java
@@ -1,0 +1,40 @@
+package backend.yourtrip.domain.uploadcourse.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalTime;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record PlaceUpdateRequest(
+    @Schema(description = "장소 ID (기존 장소 수정 시 전달, 신규 장소 추가 시 null)", example = "1")
+    Long placeId,
+
+    @Schema(description = "장소 이름", example = "황리단길 카페 거리")
+    @NotBlank(message = "장소 이름은 필수입니다.")
+    String placeName,
+
+    @Schema(description = "방문 시작 시간", example = "10:30:00")
+    LocalTime startTime,
+
+    @Schema(description = "장소 메모", example = "감성 카페 골목 산책")
+    String memo,
+
+    @Schema(description = "위도", example = "35.8375")
+    double latitude,
+
+    @Schema(description = "경도", example = "129.2123")
+    double longitude,
+
+    @Schema(description = "카카오 지도 장소 URL", example = "http://place.map.kakao.com/26338954")
+    String placeUrl,
+
+    @Schema(description = "장소 주소", example = "경북 경주시 포석로 인근")
+    String placeLocation,
+
+    @Schema(description = "장소 사진 수정 목록 (기존 사진 유지 및 신규 사진 인덱스 매핑)")
+    List<PlaceImageUpdateRequest> placeImages
+) {
+
+}

--- a/src/main/java/backend/yourtrip/domain/uploadcourse/dto/request/UploadCourseUpdateRequest.java
+++ b/src/main/java/backend/yourtrip/domain/uploadcourse/dto/request/UploadCourseUpdateRequest.java
@@ -1,0 +1,46 @@
+package backend.yourtrip.domain.uploadcourse.dto.request;
+
+import backend.yourtrip.domain.uploadcourse.entity.enums.KeywordType;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record UploadCourseUpdateRequest(
+    @Schema(example = "경주 인생샷 1일 코스 (수정본)")
+    @NotBlank(message = "코스 제목은 필수 입력입니다.")
+    String title,
+
+    @Schema(example = "황리단길부터 첨성대까지, 인생샷 남기기 좋은 스팟만 모았어요.")
+    String introduction,
+
+    @Schema(example = "경주")
+    String location,
+
+    @Schema(example = "2025-03-01")
+    @NotNull(message = "시작일은 필수 입력입니다.")
+    LocalDate startDate,
+
+    @Schema(example = "2025-03-01")
+    @NotNull(message = "종료일은 필수 입력입니다.")
+    LocalDate endDate,
+
+    @ArraySchema(
+        schema = @Schema(implementation = KeywordType.class),
+        arraySchema = @Schema(example = "[\"WALK\", \"FOOD\", \"HEALING\"]")
+    )
+    @NotNull(message = "키워드 목록은 필수 입력값입니다. 선택된 키워드가 없을 시 빈 배열을 전송해주세요")
+    List<KeywordType> keywords,
+
+    @Schema(description = "일차별 장소 일정 목록")
+    @NotNull(message = "일정 목록은 필수 입력입니다.")
+    @Valid
+    List<DayScheduleUpdateRequest> daySchedules
+) {
+
+}

--- a/src/main/java/backend/yourtrip/domain/uploadcourse/entity/UploadCourse.java
+++ b/src/main/java/backend/yourtrip/domain/uploadcourse/entity/UploadCourse.java
@@ -53,7 +53,7 @@ public class UploadCourse extends BaseEntity {
 
     private boolean deleted;
 
-    @OneToMany(mappedBy = "uploadCourse", cascade = CascadeType.PERSIST)
+    @OneToMany(mappedBy = "uploadCourse", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CourseKeyword> keywords;
 
     private String location;
@@ -80,4 +80,13 @@ public class UploadCourse extends BaseEntity {
         this.forkCount += 1;
     }
 
+    public void updateUploadCourseInfo(String title, String introduction, String location,
+        String thumbnailImageS3Key) {
+        this.title = title;
+        this.introduction = introduction;
+        this.location = location;
+        if (thumbnailImageS3Key != null) {
+            this.thumbnailImageS3Key = thumbnailImageS3Key;
+        }
+    }
 }

--- a/src/main/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseService.java
+++ b/src/main/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseService.java
@@ -1,6 +1,7 @@
 package backend.yourtrip.domain.uploadcourse.service;
 
 import backend.yourtrip.domain.uploadcourse.dto.request.UploadCourseCreateRequest;
+import backend.yourtrip.domain.uploadcourse.dto.request.UploadCourseUpdateRequest;
 import backend.yourtrip.domain.uploadcourse.dto.response.CourseKeywordListResponse;
 import backend.yourtrip.domain.uploadcourse.dto.response.UploadCourseCreateResponse;
 import backend.yourtrip.domain.uploadcourse.dto.response.UploadCourseDetailResponse;
@@ -25,4 +26,8 @@ public interface UploadCourseService {
     UploadCourseListResponse getMyUploadCourses();
 
     UploadCourseListResponse getPopularCourses(KeywordType theme);
+
+    UploadCourseDetailResponse updateUploadCourse(Long uploadCourseId,
+        UploadCourseUpdateRequest request, MultipartFile thumbnailImage,
+        List<MultipartFile> placeImages);
 }

--- a/src/main/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseServiceImpl.java
+++ b/src/main/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseServiceImpl.java
@@ -603,20 +603,6 @@ public class UploadCourseServiceImpl implements UploadCourseService {
             travelCourse.getDaySchedules().remove(ds);
         }
 
-        // 5. 캐시 삭제/초기화 (Fail-Open)
-        try {
-            Cache cache = cacheManager.getCache(COURSE_LIST_ITEM_CACHE);
-            if (cache != null) {
-                cache.evict(uploadCourseId.toString());
-            }
-            Cache popularCache = cacheManager.getCache(POPULAR_COURSES_CACHE);
-            if (popularCache != null) {
-                popularCache.clear();
-            }
-        } catch (Exception e) {
-            log.warn("수정 중 캐시 삭제 실패. uploadCourseId={}", uploadCourseId, e);
-        }
-
         List<DayScheduleResponse> updatedDaySchedules = myCourseService.getAllDaySchedulesByCourse(travelCourse.getId());
         return UploadCourseMapper.toDetailResponse(uploadCourse, getGetThumbnailUrl(uploadCourse), updatedDaySchedules);
     }

--- a/src/main/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseServiceImpl.java
+++ b/src/main/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseServiceImpl.java
@@ -4,7 +4,14 @@ import backend.yourtrip.domain.mycourse.dto.response.DayScheduleResponse;
 import backend.yourtrip.domain.mycourse.entity.travelCourse.TravelCourse;
 import backend.yourtrip.domain.mycourse.service.MyCourseService;
 import backend.yourtrip.domain.uploadcourse.dto.cache.CourseListItemCacheItem;
+import backend.yourtrip.domain.mycourse.entity.dayschedule.DaySchedule;
+import backend.yourtrip.domain.mycourse.entity.place.Place;
+import backend.yourtrip.domain.mycourse.entity.place.PlaceImage;
+import backend.yourtrip.domain.uploadcourse.dto.request.DayScheduleUpdateRequest;
+import backend.yourtrip.domain.uploadcourse.dto.request.PlaceImageUpdateRequest;
+import backend.yourtrip.domain.uploadcourse.dto.request.PlaceUpdateRequest;
 import backend.yourtrip.domain.uploadcourse.dto.request.UploadCourseCreateRequest;
+import backend.yourtrip.domain.uploadcourse.dto.request.UploadCourseUpdateRequest;
 import backend.yourtrip.domain.uploadcourse.dto.response.CourseKeywordListResponse;
 import backend.yourtrip.domain.uploadcourse.dto.response.UploadCourseCreateResponse;
 import backend.yourtrip.domain.uploadcourse.dto.response.UploadCourseDetailResponse;
@@ -25,10 +32,14 @@ import backend.yourtrip.global.s3.service.S3Service;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.Cache;
@@ -450,4 +461,163 @@ public class UploadCourseServiceImpl implements UploadCourseService {
         return thumbnailUrl;
     }
 
+    @Override
+    @Transactional
+    public UploadCourseDetailResponse updateUploadCourse(Long uploadCourseId,
+        UploadCourseUpdateRequest request, MultipartFile thumbnailImage,
+        List<MultipartFile> placeImages) {
+        UploadCourse uploadCourse = uploadCourseRepository.findWithTravelCourseAndKeywords(uploadCourseId)
+            .orElseThrow(() -> new BusinessException(UploadCourseErrorCode.UPLOAD_COURSE_NOT_FOUND));
+
+        Long currentUserId = userService.getCurrentUserId();
+        if (!uploadCourse.getUser().getId().equals(currentUserId)) {
+            throw new BusinessException(UploadCourseErrorCode.NOT_OWNED_UPLOAD_COURSE);
+        }
+
+        // 1. 썸네일 이미지 업데이트 (신규 이미지 첨부 시 기존 S3 파일 삭제 후 저장)
+        String newThumbnailS3Key = uploadCourse.getThumbnailImageS3Key();
+        if (thumbnailImage != null && !thumbnailImage.isEmpty()) {
+            if (newThumbnailS3Key != null && !"default-upload-course-thumbnail.png".equals(newThumbnailS3Key)) {
+                s3Service.deleteFile(newThumbnailS3Key);
+            }
+            try {
+                newThumbnailS3Key = s3Service.uploadFile(thumbnailImage).key();
+            } catch (IOException e) {
+                throw new BusinessException(S3ErrorCode.FAIL_UPLOAD_FILE);
+            }
+        }
+
+        // 2. UploadCourse 정보 및 키워드 갱신
+        uploadCourse.updateUploadCourseInfo(request.title(), request.introduction(), request.location(), newThumbnailS3Key);
+
+        uploadCourse.getKeywords().clear();
+        if (request.keywords() != null) {
+            for (KeywordType keyword : request.keywords()) {
+                uploadCourse.getKeywords().add(new CourseKeyword(uploadCourse, keyword));
+            }
+        }
+
+        // 3. TravelCourse 정보 갱신
+        TravelCourse travelCourse = uploadCourse.getTravelCourse();
+        travelCourse.updateCourseInfo(request.title(), request.location(), request.startDate(), request.endDate());
+
+        // 4. DaySchedule, Place, PlaceImage 매칭 및 동기화 (갱신/추가/삭제)
+        List<DaySchedule> existingDaySchedules = myCourseService.getDaySchedulesWithPlaces(travelCourse.getId());
+
+        Map<Long, DaySchedule> existingDayMap = existingDaySchedules.stream()
+            .collect(Collectors.toMap(DaySchedule::getId, Function.identity()));
+
+        Map<Long, Place> existingPlaceMap = existingDaySchedules.stream()
+            .flatMap(ds -> ds.getPlaces().stream())
+            .collect(Collectors.toMap(Place::getId, Function.identity()));
+
+        Map<Long, PlaceImage> existingImageMap = existingDaySchedules.stream()
+            .flatMap(ds -> ds.getPlaces().stream())
+            .flatMap(p -> p.getPlaceImages().stream())
+            .collect(Collectors.toMap(PlaceImage::getId, Function.identity()));
+
+        Set<Long> requestedDayIds = new HashSet<>();
+        Set<Long> requestedPlaceIds = new HashSet<>();
+        Set<Long> requestedImageIds = new HashSet<>();
+
+        if (request.daySchedules() != null) {
+            for (DayScheduleUpdateRequest dayDto : request.daySchedules()) {
+                DaySchedule daySchedule;
+                if (dayDto.dayScheduleId() != null && existingDayMap.containsKey(dayDto.dayScheduleId())) {
+                    daySchedule = existingDayMap.get(dayDto.dayScheduleId());
+                    requestedDayIds.add(daySchedule.getId());
+                } else {
+                    daySchedule = new DaySchedule(travelCourse, dayDto.day());
+                    travelCourse.getDaySchedules().add(daySchedule);
+                }
+
+                if (dayDto.places() != null) {
+                    for (PlaceUpdateRequest placeDto : dayDto.places()) {
+                        Place place;
+                        if (placeDto.placeId() != null && existingPlaceMap.containsKey(placeDto.placeId())) {
+                            place = existingPlaceMap.get(placeDto.placeId());
+                            place.updatePlaceInfo(placeDto.placeName(), placeDto.startTime(), placeDto.memo(),
+                                placeDto.latitude(), placeDto.longitude(), placeDto.placeUrl(), placeDto.placeLocation());
+                            requestedPlaceIds.add(place.getId());
+                        } else {
+                            place = Place.builder()
+                                .daySchedule(daySchedule)
+                                .placeName(placeDto.placeName())
+                                .startTime(placeDto.startTime())
+                                .memo(placeDto.memo())
+                                .latitude(placeDto.latitude())
+                                .longitude(placeDto.longitude())
+                                .placeUrl(placeDto.placeUrl())
+                                .placeLocation(placeDto.placeLocation())
+                                .build();
+                            daySchedule.getPlaces().add(place);
+                        }
+
+                        if (placeDto.placeImages() != null) {
+                            for (PlaceImageUpdateRequest imgDto : placeDto.placeImages()) {
+                                if (imgDto.placeImageId() != null && existingImageMap.containsKey(imgDto.placeImageId())) {
+                                    requestedImageIds.add(imgDto.placeImageId());
+                                } else if (imgDto.newImageIndex() != null && placeImages != null
+                                    && imgDto.newImageIndex() >= 0 && imgDto.newImageIndex() < placeImages.size()) {
+                                    MultipartFile newFile = placeImages.get(imgDto.newImageIndex());
+                                    if (newFile != null && !newFile.isEmpty()) {
+                                        try {
+                                            String imageS3Key = s3Service.uploadFile(newFile).key();
+                                            place.getPlaceImages().add(new PlaceImage(place, imageS3Key));
+                                        } catch (IOException e) {
+                                            throw new BusinessException(S3ErrorCode.FAIL_UPLOAD_FILE);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        // 요청에 포함되지 않은 기존 장소 이미지 삭제 (S3 및 DB)
+                        List<PlaceImage> imagesToRemove = place.getPlaceImages().stream()
+                            .filter(img -> img.getId() != null && !requestedImageIds.contains(img.getId()))
+                            .toList();
+                        for (PlaceImage img : imagesToRemove) {
+                            s3Service.deleteFile(img.getPlaceImageS3Key());
+                            place.getPlaceImages().remove(img);
+                        }
+                    }
+                }
+
+                // 요청에 포함되지 않은 기존 장소 삭제 (S3 및 DB)
+                List<Place> placesToRemove = daySchedule.getPlaces().stream()
+                    .filter(p -> p.getId() != null && !requestedPlaceIds.contains(p.getId()))
+                    .toList();
+                for (Place p : placesToRemove) {
+                    p.getPlaceImages().forEach(img -> s3Service.deleteFile(img.getPlaceImageS3Key()));
+                    daySchedule.getPlaces().remove(p);
+                }
+            }
+        }
+
+        // 요청에 포함되지 않은 기존 일차 삭제 (S3 및 DB)
+        List<DaySchedule> daysToRemove = travelCourse.getDaySchedules().stream()
+            .filter(ds -> ds.getId() != null && !requestedDayIds.contains(ds.getId()))
+            .toList();
+        for (DaySchedule ds : daysToRemove) {
+            ds.getPlaces().forEach(p -> p.getPlaceImages().forEach(img -> s3Service.deleteFile(img.getPlaceImageS3Key())));
+            travelCourse.getDaySchedules().remove(ds);
+        }
+
+        // 5. 캐시 삭제/초기화 (Fail-Open)
+        try {
+            Cache cache = cacheManager.getCache(COURSE_LIST_ITEM_CACHE);
+            if (cache != null) {
+                cache.evict(uploadCourseId.toString());
+            }
+            Cache popularCache = cacheManager.getCache(POPULAR_COURSES_CACHE);
+            if (popularCache != null) {
+                popularCache.clear();
+            }
+        } catch (Exception e) {
+            log.warn("수정 중 캐시 삭제 실패. uploadCourseId={}", uploadCourseId, e);
+        }
+
+        List<DayScheduleResponse> updatedDaySchedules = myCourseService.getAllDaySchedulesByCourse(travelCourse.getId());
+        return UploadCourseMapper.toDetailResponse(uploadCourse, getGetThumbnailUrl(uploadCourse), updatedDaySchedules);
+    }
 }

--- a/src/main/java/backend/yourtrip/global/exception/errorCode/UploadCourseErrorCode.java
+++ b/src/main/java/backend/yourtrip/global/exception/errorCode/UploadCourseErrorCode.java
@@ -11,7 +11,8 @@ public enum UploadCourseErrorCode implements ErrorCode {
     UPLOAD_COURSE_NOT_FOUND("업로드 코스를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     INVALID_SORT_TYPE("올바르지 않는 정렬 기준입니다.", HttpStatus.BAD_REQUEST),
     COURSE_ALREADY_UPLOAD("이미 업로드된 코스입니다.", HttpStatus.BAD_REQUEST),
-    INVALID_THEME_TYPE("올바르지 않은 테마입니다.", HttpStatus.BAD_REQUEST);
+    INVALID_THEME_TYPE("올바르지 않은 테마입니다.", HttpStatus.BAD_REQUEST),
+    NOT_OWNED_UPLOAD_COURSE("본인이 업로드한 코스만 수정할 수 있습니다.", HttpStatus.FORBIDDEN);
 
     private final String message;
     private final HttpStatus status;

--- a/src/test/java/backend/yourtrip/domain/uploadcourse/controller/UploadCourseControllerE2ETest.java
+++ b/src/test/java/backend/yourtrip/domain/uploadcourse/controller/UploadCourseControllerE2ETest.java
@@ -1,0 +1,193 @@
+package backend.yourtrip.domain.uploadcourse.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import backend.yourtrip.domain.mycourse.dto.response.DayScheduleResponse;
+import backend.yourtrip.domain.uploadcourse.dto.request.DayScheduleUpdateRequest;
+import backend.yourtrip.domain.uploadcourse.dto.request.PlaceUpdateRequest;
+import backend.yourtrip.domain.uploadcourse.dto.request.UploadCourseUpdateRequest;
+import backend.yourtrip.domain.uploadcourse.dto.response.UploadCourseDetailResponse;
+import backend.yourtrip.domain.uploadcourse.entity.enums.KeywordType;
+import backend.yourtrip.domain.uploadcourse.service.UploadCourseService;
+import backend.yourtrip.domain.user.repository.UserRepository;
+import backend.yourtrip.global.jwt.JwtTokenProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class UploadCourseControllerE2ETest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private UploadCourseService uploadCourseService;
+
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("PUT /api/upload-courses/{uploadCourseId} - 로그인한 사용자가 정상적인 정보로 수정 시 200 OK와 수정된 코스 상세 응답을 반환한다")
+    @WithMockUser
+    void updateUploadCourse_Success() throws Exception {
+        // given
+        Long uploadCourseId = 1L;
+
+        UploadCourseUpdateRequest requestDto = UploadCourseUpdateRequest.builder()
+            .title("경주 인생샷 코스 (수정본)")
+            .introduction("황리단길과 첨성대 야경 수정 완료")
+            .location("경주")
+            .startDate(LocalDate.of(2025, 3, 1))
+            .endDate(LocalDate.of(2025, 3, 1))
+            .keywords(List.of(KeywordType.WALK, KeywordType.FOOD))
+            .daySchedules(List.of(
+                DayScheduleUpdateRequest.builder()
+                    .dayScheduleId(100L)
+                    .day(1)
+                    .places(List.of(
+                        PlaceUpdateRequest.builder()
+                            .placeId(200L)
+                            .placeName("황리단길 카페 거리")
+                            .startTime(LocalTime.of(10, 30))
+                            .memo("카페 골목 산책")
+                            .latitude(35.8375)
+                            .longitude(129.2123)
+                            .placeUrl("http://place.map.kakao.com/26338954")
+                            .placeLocation("경북 경주시 포석로 인근")
+                            .build()
+                    ))
+                    .build()
+            ))
+            .build();
+
+        MockMultipartFile requestPart = new MockMultipartFile(
+            "request",
+            "",
+            MediaType.APPLICATION_JSON_VALUE,
+            objectMapper.writeValueAsString(requestDto).getBytes()
+        );
+
+        MockMultipartFile thumbnailPart = new MockMultipartFile(
+            "thumbnailImage",
+            "thumbnail.png",
+            MediaType.IMAGE_PNG_VALUE,
+            "fake thumbnail content".getBytes()
+        );
+
+        UploadCourseDetailResponse expectedResponse = UploadCourseDetailResponse.builder()
+            .uploadCourseId(uploadCourseId)
+            .title("경주 인생샷 코스 (수정본)")
+            .introduction("황리단길과 첨성대 야경 수정 완료")
+            .location("경주")
+            .thumbnailImageUrl("http://s3.com/thumbnail.png")
+            .startDate(LocalDate.of(2025, 3, 1))
+            .endDate(LocalDate.of(2025, 3, 1))
+            .forkCount(5)
+            .keywords(List.of("뚜벅이", "맛집탐방"))
+            .daySchedules(List.of(
+                new DayScheduleResponse(100L, 1, List.of())
+            ))
+            .build();
+
+        given(uploadCourseService.updateUploadCourse(eq(uploadCourseId), any(), any(), any()))
+            .willReturn(expectedResponse);
+
+        // when & then
+        mockMvc.perform(multipart(HttpMethod.PUT, "/api/upload-courses/{uploadCourseId}", uploadCourseId)
+                .file(requestPart)
+                .file(thumbnailPart)
+                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.uploadCourseId").value(uploadCourseId))
+            .andExpect(jsonPath("$.title").value("경주 인생샷 코스 (수정본)"))
+            .andExpect(jsonPath("$.introduction").value("황리단길과 첨성대 야경 수정 완료"))
+            .andExpect(jsonPath("$.location").value("경주"))
+            .andExpect(jsonPath("$.thumbnailImageUrl").value("http://s3.com/thumbnail.png"));
+    }
+
+    @Test
+    @DisplayName("PUT /api/upload-courses/{uploadCourseId} - 비인증 사용자가 요청 시 401/403 응답을 반환한다")
+    void updateUploadCourse_Unauthenticated_ReturnsForbiddenOrUnauthorized() throws Exception {
+        // given
+        Long uploadCourseId = 1L;
+
+        UploadCourseUpdateRequest requestDto = UploadCourseUpdateRequest.builder()
+            .title("제목")
+            .startDate(LocalDate.now())
+            .endDate(LocalDate.now())
+            .keywords(List.of())
+            .daySchedules(List.of())
+            .build();
+
+        MockMultipartFile requestPart = new MockMultipartFile(
+            "request",
+            "",
+            MediaType.APPLICATION_JSON_VALUE,
+            objectMapper.writeValueAsString(requestDto).getBytes()
+        );
+
+        // when & then
+        mockMvc.perform(multipart(HttpMethod.PUT, "/api/upload-courses/{uploadCourseId}", uploadCourseId)
+                .file(requestPart)
+                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .andDo(print())
+            .andExpect(status().is4xxClientError());
+    }
+
+    @Test
+    @DisplayName("PUT /api/upload-courses/{uploadCourseId} - 제목이 비어있는 검증 실패 요청 시 400 Bad Request를 반환한다")
+    @WithMockUser
+    void updateUploadCourse_ValidationFailed_ReturnsBadRequest() throws Exception {
+        // given
+        Long uploadCourseId = 1L;
+
+        UploadCourseUpdateRequest requestDto = UploadCourseUpdateRequest.builder()
+            .title("") // 빈 제목 (Validation 실패)
+            .startDate(LocalDate.now())
+            .endDate(LocalDate.now())
+            .keywords(List.of())
+            .daySchedules(List.of())
+            .build();
+
+        MockMultipartFile requestPart = new MockMultipartFile(
+            "request",
+            "",
+            MediaType.APPLICATION_JSON_VALUE,
+            objectMapper.writeValueAsString(requestDto).getBytes()
+        );
+
+        // when & then
+        mockMvc.perform(multipart(HttpMethod.PUT, "/api/upload-courses/{uploadCourseId}", uploadCourseId)
+                .file(requestPart)
+                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .andDo(print())
+            .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseServiceImplTest.java
+++ b/src/test/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseServiceImplTest.java
@@ -1,0 +1,216 @@
+package backend.yourtrip.domain.uploadcourse.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import backend.yourtrip.domain.mycourse.dto.response.DayScheduleResponse;
+import backend.yourtrip.domain.mycourse.entity.dayschedule.DaySchedule;
+import backend.yourtrip.domain.mycourse.entity.place.Place;
+import backend.yourtrip.domain.mycourse.entity.travelCourse.TravelCourse;
+import backend.yourtrip.domain.mycourse.entity.travelCourse.enums.TravelCourseType;
+import backend.yourtrip.domain.mycourse.service.MyCourseService;
+import backend.yourtrip.domain.uploadcourse.dto.request.DayScheduleUpdateRequest;
+import backend.yourtrip.domain.uploadcourse.dto.request.PlaceUpdateRequest;
+import backend.yourtrip.domain.uploadcourse.dto.request.UploadCourseUpdateRequest;
+import backend.yourtrip.domain.uploadcourse.dto.response.UploadCourseDetailResponse;
+import backend.yourtrip.domain.uploadcourse.entity.UploadCourse;
+import backend.yourtrip.domain.uploadcourse.entity.enums.KeywordType;
+import backend.yourtrip.domain.uploadcourse.repository.UploadCourseRepository;
+import backend.yourtrip.domain.user.entity.User;
+import backend.yourtrip.domain.user.service.UserService;
+import backend.yourtrip.global.exception.BusinessException;
+import backend.yourtrip.global.exception.errorCode.UploadCourseErrorCode;
+import backend.yourtrip.global.s3.service.S3Service;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.CacheManager;
+
+@ExtendWith(MockitoExtension.class)
+class UploadCourseServiceImplTest {
+
+    @Mock
+    private UploadCourseRepository uploadCourseRepository;
+
+    @Mock
+    private MyCourseService myCourseService;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private S3Service s3Service;
+
+    @Mock
+    private CacheManager cacheManager;
+
+    @InjectMocks
+    private UploadCourseServiceImpl uploadCourseService;
+
+    @Test
+    @DisplayName("작성자가 아닌 사용자가 코스 수정을 시도하면 NOT_OWNED_UPLOAD_COURSE 예외가 발생한다")
+    void updateUploadCourse_NotOwner_ThrowsException() {
+        // given
+        Long uploadCourseId = 1L;
+        Long ownerId = 10L;
+        Long otherUserId = 20L;
+
+        User owner = User.builder().email("owner@test.com").password("pass").nickname("owner").build();
+        setEntityId(owner, ownerId);
+
+        TravelCourse travelCourse = TravelCourse.builder()
+            .user(owner)
+            .title("원래 제목")
+            .location("경주")
+            .startDate(LocalDate.now())
+            .endDate(LocalDate.now())
+            .type(TravelCourseType.UPLOADED)
+            .build();
+
+        UploadCourse uploadCourse = UploadCourse.builder()
+            .title("원래 제목")
+            .introduction("소개")
+            .thumbnailImageS3Key("thumb.png")
+            .travelCourse(travelCourse)
+            .user(owner)
+            .location("경주")
+            .build();
+
+        given(uploadCourseRepository.findWithTravelCourseAndKeywords(uploadCourseId))
+            .willReturn(Optional.of(uploadCourse));
+        given(userService.getCurrentUserId()).willReturn(otherUserId);
+
+        UploadCourseUpdateRequest request = UploadCourseUpdateRequest.builder()
+            .title("수정된 제목")
+            .startDate(LocalDate.now())
+            .endDate(LocalDate.now())
+            .keywords(List.of())
+            .daySchedules(List.of())
+            .build();
+
+        // when & then
+        assertThatThrownBy(() -> uploadCourseService.updateUploadCourse(uploadCourseId, request, null, null))
+            .isInstanceOf(BusinessException.class)
+            .hasFieldOrPropertyWithValue("errorCode", UploadCourseErrorCode.NOT_OWNED_UPLOAD_COURSE);
+    }
+
+    @Test
+    @DisplayName("작성자가 업로드 코스를 수정하면 정보가 올바르게 갱신된다")
+    void updateUploadCourse_Success() {
+        // given
+        Long uploadCourseId = 1L;
+        Long ownerId = 10L;
+
+        User owner = User.builder().email("owner@test.com").password("pass").nickname("owner").build();
+        setEntityId(owner, ownerId);
+
+        TravelCourse travelCourse = TravelCourse.builder()
+            .user(owner)
+            .title("원래 제목")
+            .location("경주")
+            .startDate(LocalDate.of(2025, 3, 1))
+            .endDate(LocalDate.of(2025, 3, 1))
+            .type(TravelCourseType.UPLOADED)
+            .build();
+        setEntityId(travelCourse, 100L);
+
+        DaySchedule daySchedule = DaySchedule.builder()
+            .course(travelCourse)
+            .day(1)
+            .build();
+        setEntityId(daySchedule, 1000L);
+        travelCourse.getDaySchedules().add(daySchedule);
+
+        Place place = Place.builder()
+            .daySchedule(daySchedule)
+            .placeName("황리단길")
+            .startTime(LocalTime.of(10, 0))
+            .memo("메모")
+            .latitude(35.8)
+            .longitude(129.2)
+            .placeUrl("http://kakao.com")
+            .placeLocation("경주")
+            .build();
+        setEntityId(place, 2000L);
+        daySchedule.getPlaces().add(place);
+
+        UploadCourse uploadCourse = UploadCourse.builder()
+            .title("원래 제목")
+            .introduction("소개")
+            .thumbnailImageS3Key("thumb.png")
+            .travelCourse(travelCourse)
+            .user(owner)
+            .location("경주")
+            .build();
+
+        given(uploadCourseRepository.findWithTravelCourseAndKeywords(uploadCourseId))
+            .willReturn(Optional.of(uploadCourse));
+        given(userService.getCurrentUserId()).willReturn(ownerId);
+        given(myCourseService.getDaySchedulesWithPlaces(100L)).willReturn(List.of(daySchedule));
+        given(myCourseService.getAllDaySchedulesByCourse(100L)).willReturn(List.of(
+            new DayScheduleResponse(1000L, 1, List.of())
+        ));
+        given(s3Service.getPresignedUrl("thumb.png")).willReturn("http://s3.com/thumb.png");
+
+        UploadCourseUpdateRequest request = UploadCourseUpdateRequest.builder()
+            .title("수정된 경주 여행")
+            .introduction("수정된 소개글")
+            .location("경주 황리단길")
+            .startDate(LocalDate.of(2025, 3, 1))
+            .endDate(LocalDate.of(2025, 3, 1))
+            .keywords(List.of(KeywordType.WALK, KeywordType.FOOD))
+            .daySchedules(List.of(
+                DayScheduleUpdateRequest.builder()
+                    .dayScheduleId(1000L)
+                    .day(1)
+                    .places(List.of(
+                        PlaceUpdateRequest.builder()
+                            .placeId(2000L)
+                            .placeName("수정된 황리단길")
+                            .startTime(LocalTime.of(11, 0))
+                            .memo("수정된 메모")
+                            .latitude(35.9)
+                            .longitude(129.3)
+                            .placeUrl("http://kakao.com/new")
+                            .placeLocation("경주 포석로")
+                            .placeImages(List.of())
+                            .build()
+                    ))
+                    .build()
+            ))
+            .build();
+
+        // when
+        UploadCourseDetailResponse response = uploadCourseService.updateUploadCourse(uploadCourseId, request, null, null);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(uploadCourse.getTitle()).isEqualTo("수정된 경주 여행");
+        assertThat(uploadCourse.getIntroduction()).isEqualTo("수정된 소개글");
+        assertThat(uploadCourse.getLocation()).isEqualTo("경주 황리단길");
+        assertThat(uploadCourse.getKeywords()).hasSize(2);
+        assertThat(travelCourse.getTitle()).isEqualTo("수정된 경주 여행");
+        assertThat(place.getPlaceName()).isEqualTo("수정된 황리단길");
+    }
+
+    private void setEntityId(Object entity, Long id) {
+        try {
+            java.lang.reflect.Field field = entity.getClass().getDeclaredField("id");
+            field.setAccessible(true);
+            field.set(entity, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
## ✅ 작업 내용

### 업로드 코스 통합 수정 API 구현 (\PUT /api/upload-courses/{uploadCourseId}\)
- 업로드된 여행 코스의 주요 정보(제목, 소개, 위치, 여행 기간, 키워드, 썸네일 이미지, 일차별 일정 및 장소 사진)를 단일 API로 한꺼번에 수정할 수 있다.
- 작성자 본인만 수정이 가능하도록 소유권 검증 로직을 포함하여, 타인이 수정 시도 시 403 Forbidden (\NOT_OWNED_UPLOAD_COURSE\)을 반환한다.
- 썸네일 이미지 미전달(null) 시 기존 썸네일이 유지되며, 신규 파일 전달 시 기존 S3 파일 삭제 후 신규 업로드된다.
- 요청 DTO의 PK ID (\dayScheduleId\, \placeId\, \placeImageId\) 포함 여부에 따라 기존 엔티티 갱신, 신규 엔티티 추가, 목록에서 누락된 기존 엔티티 삭제 및 S3 이미지 정리가 자동 수행된다.

### API 명세 및 테스트 구현
- Swagger OpenAPI 문서 명세 (\UploadCourseControllerSpec\) 및 프론트엔드 공유용 API 변경 문서 (\docs/api-changes/upload-course-update.md\)를 작성했다.
- 서비스 단위 테스트 (\UploadCourseServiceImplTest\) 및 MockMvc 기반 API E2E/통합 테스트 (\UploadCourseControllerE2ETest\)를 작성하고 100% 통과 검증했다.

## 📌 관련 이슈

closes #53

## 📚 추가 리팩토링 가능성

- **코스 수정 시 캐시 무효화 (Cache Eviction) 정책 추가**: 코스 수정 시 코스 목록 캐시(\COURSE_LIST_ITEM_CACHE\) 및 인기 코스 랭킹 캐시(\POPULAR_COURSES_CACHE\)를 무효화/초기화하여 Stale Data를 방지하는 정책 도입 제안.
- **S3 이미지 트랜잭션 보상 처리 (Transactional Event Listener)**: DB 수정 트랜잭션 실패/롤백 시 이미 처리된 S3 파일 업로드 및 삭제의 정합성을 보장하기 위해, \@TransactionalEventListener(phase = AFTER_COMMIT / AFTER_ROLLBACK)\ 기반의 S3 cleanup 이벤트 핸들러 도입 제안.