### PR TITLE
feat: k6 부하 테스트 및 Prometheus/Grafana 모니터링 환경 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.apache.commons:commons-pool2'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,23 @@ services:
     # allkeys-lru: 순수 캐시 용도(원본은 항상 DB)이므로 메모리 초과 시
     # noeviction(기본값)처럼 쓰기 실패를 내지 않고 오래된 키부터 자동 축출한다.
     command: redis-server --maxmemory 256mb --maxmemory-policy allkeys-lru
+
+  prometheus:
+    image: prom/prometheus:v2.51.0
+    container_name: yourtrip-prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  grafana:
+    image: grafana/grafana:10.4.0
+    container_name: yourtrip-grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    depends_on:
+      - prometheus

--- a/docs/CACHING-ROADMAP.md
+++ b/docs/CACHING-ROADMAP.md
@@ -14,20 +14,7 @@
 **① 목록 조회가 매번 전체 스캔이다.**
 `UploadCourseRepository.findAllByKeywordsOrderByViewCountDesc`([UploadCourseRepository.java:66-81](../src/main/java/backend/yourtrip/domain/uploadcourse/repository/UploadCourseRepository.java))는 `UploadCourse` 전체를 `LEFT JOIN FETCH` + 상관 서브쿼리로 훑고, 페이징이 없어 데이터가 늘수록 선형으로 느려진다.
 
-**② 조회수가 DB에 반영되지 않는다.**
-[UploadCourseServiceImpl.java:85-92](../src/main/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseServiceImpl.java)의 `getDetail`은 `@Transactional(readOnly = true)`인데 그 안에서 `increaseViewCount()`를 호출한다.
-
-- JPA는 트랜잭션 안에서 엔티티 필드를 바꾸면(`increaseViewCount()`), 트랜잭션 종료 시 자동으로 `UPDATE`를 날려주는 dirty checking을 수행한다.
-- 그런데 `readOnly = true`로 선언하면 Spring/Hibernate는 "이 트랜잭션은 쓰기가 없다"고 가정하고 FlushMode를 `MANUAL`로 바꿔 자동 flush 자체를 꺼버린다.
-- 그 결과 `increaseViewCount()`는 메모리상의 객체 값만 바꿀 뿐, 그 변경이 DB로 전송되지 않는다.
-- 인기순 정렬(`ORDER BY viewCount DESC`)은 이 컬럼값을 기준으로 하므로, **정렬 기준 자체가 사실상 갱신되지 않고 있다.**
-
-가장 단순한 해법은 `readOnly = true`를 제거하는 것이지만, 그러면 **상세 조회 1회 = DB `UPDATE` 1회**가 된다. 인기 코스는 정의상 동시에 여러 사용자가 몰려서 보게 되므로, 같은 row(`upload_course_id`)에 대한 `UPDATE`가 동시에 여러 건 발생한다. DB는 UPDATE 중인 row에 락을 걸기 때문에, 동시 요청들이 줄지어 순서대로 처리되는 **락 경합**이 생긴다. 트래픽이 적을 때는 티가 안 나지만, 대용량 트래픽 가정 하에서는 인기 코스일수록 상세 조회 자체가 느려지는 새로운 병목이 된다. 즉:
-
-- 그대로 두면: 조회수 집계가 애초에 안 됨 (기능 결함)
-- 단순히 고치면: 인기 코스일수록 상세 조회가 느려짐 (성능 병목)
-
-**③ 상세 조회 1건의 비용이 목록보다 크다.**
+**② 상세 조회 1건의 비용이 목록보다 크다.**
 `findWithMyCourseAndKeywords` → `existsById` → `getDaySchedulesWithPlaces`로 쿼리가 이어지고, **장소 이미지 개수만큼 presigned URL을 생성**한다([MyCourseServiceImpl.java:200-220](../src/main/java/backend/yourtrip/domain/mycourse/service/MyCourseServiceImpl.java)). 목록만 캐싱하면 트래픽을 막는 게 아니라 상세 조회로 떠넘기는 셈이 된다.
 
 ## 설계 원칙
@@ -106,12 +93,12 @@
 - [x] 4-4. Before/After 성능 측정 (단일 인기 코스 반복 조회 vs 여러 코스 혼합 조회)
 
 ### 5. 조회수 Redis 카운터
-- [ ] 5-1. `INCR` + `SADD` 기반 카운터 증가 로직 추가 (try-catch로 Redis 장애 격리)
-- [ ] 5-2. `getDetail`의 기존 `increaseViewCount()` 호출을 Redis 카운터 호출로 교체
-- [ ] 5-3. Repository에 벌크 증분 UPDATE 쿼리 추가
-- [ ] 5-4. dirty set을 `RENAME`으로 스냅샷 떠서 배출하는 로직 추가
-- [ ] 5-5. 스케줄러 추가 (DB 벌크 반영) + `@EnableScheduling` 등록
-- [ ] 5-6. 스케줄러에 refresh-ahead(캐시 evict 대신 put) 연결
+- [x] 5-1. `INCR` + `SADD` 기반 카운터 증가 로직 추가 (try-catch로 Redis 장애 격리)
+- [x] 5-2. `getDetail`의 기존 `increaseViewCount()` 호출을 Redis 카운터 호출로 교체
+- [x] 5-3. Repository에 벌크 증분 UPDATE 쿼리 추가
+- [x] 5-4. dirty set을 `RENAME`으로 스냅샷 떠서 배출하는 로직 추가
+- [x] 5-5. 스케줄러 추가 (DB 벌크 반영) + `@EnableScheduling` 등록
+- [x] 5-6. 스케줄러에 refresh-ahead(캐시 evict 대신 put) 연결
 
 ### 6. 캐시 무효화 연결
 

--- a/docs/guide/LOAD-TESTING-GUIDE.md
+++ b/docs/guide/LOAD-TESTING-GUIDE.md
@@ -115,8 +115,24 @@ export default function () {
 ```
 
 ### 실행 명령어
+
+#### 1) 일반 실행
 ```bash
 k6 run script.js
+```
+
+#### 2) k6 웹 대시보드 및 HTML 리포트 생성 실행 (강력 추천 ⭐)
+k6 내장 웹 대시보드를 켜면 부하 테스트 중 브라우저(`http://127.0.0.1:5665`)에서 실시간 차트를 볼 수 있으며, 테스트 종료 후 단독 실행 가능한 HTML 보고서(`report.html`)를 자동 저장할 수 있습니다.
+
+```bash
+# PowerShell
+$env:K6_WEB_DASHBOARD="true"; $env:K6_WEB_DASHBOARD_EXPORT="report.html"; k6 run script.js
+
+# CMD
+set K6_WEB_DASHBOARD=true && set K6_WEB_DASHBOARD_EXPORT=report.html && k6 run script.js
+
+# 또는 k6 CLI 옵션으로 바로 지정 (가장 간편)
+k6 run --out web-dashboard=export=report.html script.js
 ```
 
 ---

--- a/docs/guide/LOAD-TESTING-GUIDE.md
+++ b/docs/guide/LOAD-TESTING-GUIDE.md
@@ -1,0 +1,131 @@
+# k6 + Actuator + Hibernate Statistics 부하 테스트 가이드
+
+이 문서는 **k6(외부 부하 생성 및 API Performance 측정)**와 **Spring Boot Actuator + Hibernate Statistics(서버 내부 DB 쿼리 수 및 커넥션 모니터링)**를 조합하여 캐싱 전후의 성능과 DB 쿼리 감소 효과를 정교하게 검증하는 방법을 안내합니다.
+
+---
+
+## 1. k6 설치 방법 (Windows)
+
+k6는 Go 언어로 작성된 독립 실행형 CLI 도구입니다. 아래 방법 중 하나로 설치합니다.
+
+### 방법 A: Windows Package Manager (`winget`) - 권장
+터미널(CMD 또는 PowerShell)에서 아래 명령어를 실행합니다.
+```powershell
+winget install k6 --source winget
+```
+
+### 방법 B: Chocolatey 사용
+```powershell
+choco install k6
+```
+
+### 설치 확인
+터미널에서 버전 명령어를 통해 정상 설치를 확인합니다.
+```powershell
+k6 version
+```
+
+---
+
+## 2. Actuator & Hibernate Statistics 주요 메트릭 엔드포인트
+
+애플리케이션 실행 후 (`http://localhost:8080`), 다음 엔드포인트를 통해 서버 내부 지표를 실시간 조회할 수 있습니다.
+
+| 메트릭 종류 | URL 엔드포인트 | 설명 |
+| :--- | :--- | :--- |
+| **SQL 쿼리 수** | `/actuator/metrics/hibernate.statements` | 애플리케이션 시작 후 실행된 **총 SQL 문장 수(Count)** |
+| **활성 DB 커넥션 수** | `/actuator/metrics/hikaricp.connections.active` | 현재 DB 쿼리를 수행 중인 커넥션 개수 |
+| **대기 커넥션 스레드 수** | `/actuator/metrics/hikaricp.connections.pending` | DB 커넥션 풀이 부족하여 대기 중인 요청 스레드 수 |
+| **휴식 중인 커넥션 수** | `/actuator/metrics/hikaricp.connections.idle` | 커넥션 풀에서 놀고 있는 커넥션 개수 |
+| **HTTP 요청 처리 수/지연**| `/actuator/metrics/http.server.requests` | HTTP 요청별 평균/최대 응답 속도 및 처리 건수 |
+
+> **curl 명령어 예시:**
+> ```bash
+> curl http://localhost:8080/actuator/metrics/hibernate.statements
+> ```
+
+---
+
+## 3. 캐싱 성능 (DB 쿼리 감소량) 검증 절차
+
+부하 테스트 중 DB 쿼리가 실제 얼마나 감소했는지 측정하는 표준 절차입니다.
+
+### 1단계: 부하 테스트 전 SQL 실행 횟수 수집 ($S_1$)
+부하 테스트를 시작하기 직전, 아래 엔드포인트를 호출하여 `COUNT` 값을 기록합니다.
+```bash
+curl -s http://localhost:8080/actuator/metrics/hibernate.statements
+```
+*응답 예시:* `{"name":"hibernate.statements","measurements":[{"statistic":"COUNT","value":15.0}]}` $\rightarrow S_1 = 15$
+
+### 2단계: k6 부하 테스트 실행 (예: 1,000건 요청)
+k6 스크립트를 통해 대상 API로 1,000건의 요청을 발사합니다.
+
+### 3단계: 부하 테스트 후 SQL 실행 횟수 수집 ($S_2$)
+부하 테스트가 종료된 직후, 동일한 엔드포인트를 호출하여 `COUNT` 값을 기록합니다.
+```bash
+curl -s http://localhost:8080/actuator/metrics/hibernate.statements
+```
+*응답 예시:* `{"name":"hibernate.statements","measurements":[{"statistic":"COUNT","value":17.0}]}` $\rightarrow S_2 = 17$
+
+### 4단계: 결과 비교 ($\Delta S = S_2 - S_1$)
+* **캐시 미적용 / Cache Miss 시**: $\Delta S \approx 1,000$ (요청 1건당 DB 쿼리 1회 이상 발생)
+* **캐시 적용 / Cache Hit 시**: $\Delta S \approx 0$ 또는 $1\sim2$ (콜드 미스 시 1~2회만 실행되고 나머지는 캐시에서 처리됨)
+
+---
+
+## 4. k6 부하 테스트 스크립트 작성 템플릿
+
+k6 스크립트 파일(예: `script.js`)을 작성할 때 참고할 수 있는 표준 템플릿입니다.
+
+```javascript
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+// 1. 부하 조건 및 성능 목표(Thresholds) 설정
+export const options = {
+  stages: [
+    { duration: '10s', target: 10 }, // 10초 동안 동시 사용자 10명으로 유입 (Ramp-up)
+    { duration: '30s', target: 50 }, // 30초 동안 동시 사용자 50명 유지
+    { duration: '10s', target: 0 },  // 10초 동안 부하 종료 (Ramp-down)
+  ],
+  thresholds: {
+    http_req_failed: ['rate<0.01'],   // 에러율 1% 미만 유지
+    http_req_duration: ['p(95)<500'], // 95%의 요청이 500ms 이내 응답
+  },
+};
+
+// 2. 테스트할 API 요청 시나리오
+export default function () {
+  const url = 'http://localhost:8080/api/upload-courses/popular';
+  const params = {
+    headers: {
+      'Content-Type': 'application.json',
+    },
+  };
+
+  const res = http.get(url, params);
+
+  // 3. 응답 검증 (HTTP status 200 OK)
+  check(res, {
+    'is status 200': (r) => r.status === 200,
+  });
+
+  sleep(0.1); // 요청 간 0.1초 휴식
+}
+```
+
+### 실행 명령어
+```bash
+k6 run script.js
+```
+
+---
+
+## 5. ⚠️ 주의 사항 (포트폴리오 팁)
+
+1. **Hibernate Statistics 옵션 관리**
+   - DB 쿼리 개수 감소를 입증할 때는 `application.yml`의 `spring.jpa.properties.hibernate.generate_statistics: true`로 설정합니다.
+   - **서버의 극단적인 최대 TPS / 응답 속도 한계**를 측정할 때는 카운터 동기화 오버헤드를 없애기 위해 해당 옵션을 `false`로 끄고 k6를 실행하는 것을 권장합니다.
+
+2. **HikariCP Pending 체크**
+   - 부하 테스트 중 `/actuator/metrics/hikaricp.connections.pending` 값이 0 초과로 지속된다면, DB 커넥션 풀 크기(`max-lifetime`, `maximum-pool-size`)가 부족하거나 DB 쿼리 실행 시간이 너무 길어 스레드가 대기 중임을 의미합니다.

--- a/docs/guide/MONITORING-GUIDE.md
+++ b/docs/guide/MONITORING-GUIDE.md
@@ -1,0 +1,109 @@
+# Prometheus & Grafana 모니터링 구축 및 사용 가이드
+
+이 문서는 Spring Boot Actuator와 Docker 기반 **Prometheus(메트릭 수집 DB)** 및 **Grafana(시각화 대시보드)**를 연동하여 애플리케이션 및 DB 상태를 실시간 모니터링하는 방법을 다룹니다.
+
+---
+
+## 1. 모니터링 아키텍처 구조
+
+```
+[ Spring Boot (Host OS:8080) ] 
+       │ /actuator/prometheus (Micrometer 메트릭 노출)
+       ▼ (5초 간격 Scraping)
+[ Prometheus (Docker Container:9090) ]
+       ▲ PromQL 쿼리 조회
+[ Grafana (Docker Container:3000) ]
+```
+
+---
+
+## 2. 모니터링 컨테이너 기동 방법
+
+프로젝트 루트 디렉토리에서 Docker Compose로 Prometheus와 Grafana를 기동합니다.
+
+```bash
+docker compose up -d
+```
+
+### 기동 상태 확인
+* **Redis**: `localhost:6479`
+* **Prometheus**: `http://localhost:9090`
+* **Grafana**: `http://localhost:3000`
+
+---
+
+## 3. Prometheus (프로메테우스) 사용법
+
+### 1) 프로메테우스 접속
+브라우저에서 `http://localhost:9090`으로 접속합니다.
+
+### 2) 넥서스 / 메트릭 수집 연결 확인 (Target Check)
+1. 상단 메뉴에서 `Status` $\rightarrow$ `Targets` 클릭합니다.
+2. `yourtrip-backend` 항목이 **`UP`** 상태인지 확인합니다.
+   * `UP`: Spring Boot 백엔드가 8080 포트로 실행 중이고 메트릭을 수집 중임.
+   * `DOWN`: Spring Boot 서버가 꺼져 있거나 포트 접근 불가.
+
+### 3) 주요 PromQL 쿼리 예시 (Prometheus 웹 UI 검색창)
+
+* **초당 SQL 쿼리 발생 비율 (Throughput)**:
+  ```promql
+  rate(hibernate_statements_total[1m])
+  ```
+* **활성 DB 커넥션 수 (HikariCP Active)**:
+  ```promql
+  hikaricp_connections_active{pool="HikariPool-1"}
+  ```
+* **대기 중인 DB 커넥션 요청 수 (HikariCP Pending)**:
+  ```promql
+  hikaricp_connections_pending{pool="HikariPool-1"}
+  ```
+* **JVM Heap 메모리 사용량 (Bytes)**:
+  ```promql
+  jvm_memory_used_bytes{area="heap"}
+  ```
+
+---
+
+## 4. Grafana (그라파나) 대시보드 설정 방법
+
+### 1) 그라파나 접속 및 로그인
+* **URL**: `http://localhost:3000`
+* **기본 아이디**: `admin`
+* **기본 비밀번호**: `admin` (첫 로그인 시 비밀번호 변경 화면이 나오면 `Skip` 또는 변경)
+
+---
+
+### 2) Prometheus 데이터 소스(Data Source) 연동
+
+1. 좌측 메뉴의 **Connections** $\rightarrow$ **Data Sources** 클릭
+2. **Add data source** 버튼 클릭 후 **Prometheus** 선택
+3. Connection URL 설정:
+   * **Prometheus server URL**: `http://prometheus:9090` (도커 내부 네트워킹 사용)
+4. 맨 아래 **Save & test** 버튼 클릭 $\rightarrow$ `"Successfully queried the Prometheus API"` 초록색 문구가 나오면 정상 연결 완료!
+
+---
+
+### 3) 완성형 Spring Boot 대시보드 가져오기 (Import Dashboard)
+
+Grafana 커뮤니티에 공개된 완성도 높은 스프링 부트 대시보드를 ID만 입력하여 1초 만에 로드할 수 있습니다.
+
+1. 좌측 메뉴의 **Dashboards** $\rightarrow$ 우측 상단 **New** 버튼 $\rightarrow$ **Import** 클릭
+2. **Find and import dashboards...** 입력창에 대시보드 ID **`11378`** 입력 후 **Load** 클릭
+   *(참고: `11378`은 "JVM (Micrometer)" 대시보드 공식 ID입니다)*
+3. 하단 **Prometheus** 데이터 소스 선택 드롭다운에서 방금 등록한 `Prometheus` 선택
+4. **Import** 버튼 클릭!
+
+🎉 **결과**: CPU, JVM 힙 메모리, Garbage Collection 타임, HTTP 요청 처리 속도, HikariCP 커넥션 풀 현황이 일목요연한 대시보드로 시각화됩니다.
+
+---
+
+## 5. 부하 테스트 시 추천 모니터링 시나리오
+
+1. **Spring Boot 실행**: `./gradlew bootRun`
+2. **Grafana 접속**: `http://localhost:3000`에서 대시보드 오픈
+3. **k6 부하 테스트 실행**: `k6 run scripts/k6/popular-courses-test.js`
+4. **대시보드 실시간 관찰**:
+   - 캐시 미적용 시: `hikaricp_connections_active`가 10(최대치)까지 상승하고 `pending` 커넥션이 생기면서 latency가 증가하는 모습 포착
+   - 캐시 적용 시: 동일한 k6 부하에도 `hikaricp_connections_active`가 거의 0~1에 머물고 응답 시간이 일정하게 유지되는 모습 포착 및 캡처
+
+> 📸 **포트폴리오 팁**: k6 실행 중 Grafana 대시보드의 캐시 적용 전/후 쿼리 그래프를 캡처하여 README 및 트러블슈팅 문서에 이미지로 첨부하면 훌륭한 시각적 근거가 됩니다!

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 5s     # 5초 간격으로 메트릭 수집 (부하 테스트 시 촘촘한 그래프 확인)
+  evaluation_interval: 5s
+
+scrape_configs:
+  - job_name: 'yourtrip-backend'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      # 호스트 OS(로컬)에서 실행 중인 Spring Boot 8080 포트를 도커 내부에서 참조하기 위해 host.docker.internal 사용
+      - targets: ['host.docker.internal:8080']

--- a/src/main/java/backend/yourtrip/global/config/SecurityConfig.java
+++ b/src/main/java/backend/yourtrip/global/config/SecurityConfig.java
@@ -44,7 +44,8 @@ public class SecurityConfig {
                     "/v3/api-docs/**",
                     "/swagger-resources/**",
                     "/swagger-resources",
-                    "/webjars/**"
+                    "/webjars/**",
+                    "/actuator/**"
                 ).permitAll()
 
                 .requestMatchers(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        generate_statistics: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
     show-sql: true
 
@@ -100,3 +101,12 @@ cloudfront:
 
 gemini:
   api-key: ${GEMINI_API_KEY}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, metrics, prometheus
+  endpoint:
+    health:
+      show-details: always

--- a/src/test/java/backend/yourtrip/domain/uploadcourse/controller/UploadCourseControllerE2ETest.java
+++ b/src/test/java/backend/yourtrip/domain/uploadcourse/controller/UploadCourseControllerE2ETest.java
@@ -2,6 +2,7 @@ package backend.yourtrip.domain.uploadcourse.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -59,38 +60,40 @@ class UploadCourseControllerE2ETest {
         // given
         Long uploadCourseId = 1L;
 
-        UploadCourseUpdateRequest requestDto = UploadCourseUpdateRequest.builder()
-            .title("경주 인생샷 코스 (수정본)")
-            .introduction("황리단길과 첨성대 야경 수정 완료")
-            .location("경주")
-            .startDate(LocalDate.of(2025, 3, 1))
-            .endDate(LocalDate.of(2025, 3, 1))
-            .keywords(List.of(KeywordType.WALK, KeywordType.FOOD))
-            .daySchedules(List.of(
-                DayScheduleUpdateRequest.builder()
-                    .dayScheduleId(100L)
-                    .day(1)
-                    .places(List.of(
-                        PlaceUpdateRequest.builder()
-                            .placeId(200L)
-                            .placeName("황리단길 카페 거리")
-                            .startTime(LocalTime.of(10, 30))
-                            .memo("카페 골목 산책")
-                            .latitude(35.8375)
-                            .longitude(129.2123)
-                            .placeUrl("http://place.map.kakao.com/26338954")
-                            .placeLocation("경북 경주시 포석로 인근")
-                            .build()
-                    ))
-                    .build()
-            ))
-            .build();
+        String requestJson = """
+            {
+              "title": "경주 인생샷 코스 (수정본)",
+              "introduction": "황리단길과 첨성대 야경 수정 완료",
+              "location": "경주",
+              "startDate": "2025-03-01",
+              "endDate": "2025-03-01",
+              "keywords": ["WALK", "FOOD"],
+              "daySchedules": [
+                {
+                  "dayScheduleId": 100,
+                  "day": 1,
+                  "places": [
+                    {
+                      "placeId": 200,
+                      "placeName": "황리단길 카페 거리",
+                      "startTime": "10:30:00",
+                      "memo": "카페 골목 산책",
+                      "latitude": 35.8375,
+                      "longitude": 129.2123,
+                      "placeUrl": "http://place.map.kakao.com/26338954",
+                      "placeLocation": "경북 경주시 포석로 인근"
+                    }
+                  ]
+                }
+              ]
+            }
+            """;
 
         MockMultipartFile requestPart = new MockMultipartFile(
             "request",
-            "",
+            "request.json",
             MediaType.APPLICATION_JSON_VALUE,
-            objectMapper.writeValueAsString(requestDto).getBytes()
+            requestJson.getBytes(java.nio.charset.StandardCharsets.UTF_8)
         );
 
         MockMultipartFile thumbnailPart = new MockMultipartFile(
@@ -115,7 +118,7 @@ class UploadCourseControllerE2ETest {
             ))
             .build();
 
-        given(uploadCourseService.updateUploadCourse(eq(uploadCourseId), any(), any(), any()))
+        given(uploadCourseService.updateUploadCourse(eq(uploadCourseId), any(), nullable(org.springframework.web.multipart.MultipartFile.class), nullable(List.class)))
             .willReturn(expectedResponse);
 
         // when & then
@@ -138,19 +141,21 @@ class UploadCourseControllerE2ETest {
         // given
         Long uploadCourseId = 1L;
 
-        UploadCourseUpdateRequest requestDto = UploadCourseUpdateRequest.builder()
-            .title("제목")
-            .startDate(LocalDate.now())
-            .endDate(LocalDate.now())
-            .keywords(List.of())
-            .daySchedules(List.of())
-            .build();
+        String requestJson = """
+            {
+              "title": "제목",
+              "startDate": "2025-03-01",
+              "endDate": "2025-03-01",
+              "keywords": [],
+              "daySchedules": []
+            }
+            """;
 
         MockMultipartFile requestPart = new MockMultipartFile(
             "request",
-            "",
+            "request.json",
             MediaType.APPLICATION_JSON_VALUE,
-            objectMapper.writeValueAsString(requestDto).getBytes()
+            requestJson.getBytes(java.nio.charset.StandardCharsets.UTF_8)
         );
 
         // when & then
@@ -168,19 +173,21 @@ class UploadCourseControllerE2ETest {
         // given
         Long uploadCourseId = 1L;
 
-        UploadCourseUpdateRequest requestDto = UploadCourseUpdateRequest.builder()
-            .title("") // 빈 제목 (Validation 실패)
-            .startDate(LocalDate.now())
-            .endDate(LocalDate.now())
-            .keywords(List.of())
-            .daySchedules(List.of())
-            .build();
+        String requestJson = """
+            {
+              "title": "",
+              "startDate": "2025-03-01",
+              "endDate": "2025-03-01",
+              "keywords": [],
+              "daySchedules": []
+            }
+            """;
 
         MockMultipartFile requestPart = new MockMultipartFile(
             "request",
-            "",
+            "request.json",
             MediaType.APPLICATION_JSON_VALUE,
-            objectMapper.writeValueAsString(requestDto).getBytes()
+            requestJson.getBytes(java.nio.charset.StandardCharsets.UTF_8)
         );
 
         // when & then


### PR DESCRIPTION
## ✅ 작업 내용

### Actuator 및 Hibernate Statistics 메트릭 수집
- `/actuator/metrics/hibernate.statements` 엔드포인트를 통해 부하 테스트 중 실행된 총 SQL 쿼리 수를 추적할 수 있다.
- `/actuator/metrics/hikaricp.connections.active` 및 `pending` 지표로 DB 커넥션 풀 병목 상태를 모니터링할 수 있다.
- 시큐리티 설정(`SecurityConfig`)에 `/actuator/**` 경로를 허용하여 부하 테스트 시 인증 없이 메트릭 조회가 가능하다.

### Prometheus & Grafana 도커 모니터링 환경
- `docker compose up -d` 명령어로 Prometheus와 Grafana 컨테이너를 한 번에 기동할 수 있다.
- Prometheus가 Spring Boot Actuator의 메트릭을 5초 간격으로 스크랩하여 시계열 데이터로 저장한다.
- Grafana에 공식 Spring Boot 대시보드(ID: `11378`)를 연동하여 CPU, JVM Heap, HikariCP 커넥션 수, 쿼리 수 변화를 실시간 대시보드로 시각화할 수 있다.

### 부하 테스트 및 모니터링 가이드 문서
- `docs/guide/LOAD-TESTING-GUIDE.md`: k6 설치 방법, k6 웹 대시보드(`--out web-dashboard`) 및 `report.html` 파일 생성 실행법, 부하 테스트 전후 DB 쿼리 감소량($\Delta S = S_2 - S_1$) 검증 수식을 안내한다.
- `docs/guide/MONITORING-GUIDE.md`: Prometheus Target 확인법, 주요 PromQL 쿼리 예시, Grafana 대시보드 연동 절차를 안내한다.

### 컨트롤러 E2E 테스트 보정
- `UploadCourseControllerE2ETest`의 MockMultipartFile JSON 페이로드 바인딩을 보정하여 전체 테스트 수트가 정상 통과한다.

## 📌 관련 이슈

## 📚 추가 리팩토링 가능성

- **Hibernate Statistics 2단계 검증 전략**
  - `generate_statistics: true` 옵션은 SQL 쿼리 수 감소를 명확하게 검증할 수 있으나, 카운팅 오버헤드가 일부 존재합니다.
  - 쿼리 감소량 입증 단계에서는 Statistics를 켜서 쿼리 수($\Delta S \approx 0$)를 검증하고, 서버의 극단적인 최대 TPS/한계 처리량을 측정할 때는 이 옵션을 `false`로 끄고 k6를 진행하는 2단계 테스트 전략을 활용할 수 있습니다.
- **k6 HTML 리포트(`report.html`) 포트폴리오 활용**
  - `k6 run --out web-dashboard=export=report.html script.js` 명령을 통해 생성된 인터랙티브 HTML 리포트를 캐싱 전후 성능 비교 문서의 시각적 근거 자료로 첨부할 수 있습니다.
