### PR TITLE
perf: 조회수 스케줄러 GETDEL을 GET→DECRBY 파이프라이닝으로 전환

### DIFF
--- a/docs/tasks/TASK-5.md
+++ b/docs/tasks/TASK-5.md
@@ -150,4 +150,44 @@ sequenceDiagram
 
 - Redis 왕복 횟수는 이론상 250배(10,000 → 40) 줄었지만, 실제 소요 시간 개선은 2.7배에 그쳤다. 원인은 명확하다 — **DB 왕복 횟수가 Before/After 동일**하기 때문이다. `applyViewCountIncrements`도 결국 `incrementViewCount(id, increment)`를 코스마다 한 번씩 개별 호출하는 구조라(멀티로우 배치 SQL이 아님), DB 쪽은 여전히 10,000회 왕복이 발생한다. 이번 변경은 "Redis 구간"만 최적화한 것이고, 측정 결과가 그 사실을 정확히 보여준다.
 - 1회차가 항상 2~3회차보다 느린 것은 JIT 워밍업, 커넥션 풀·Lettuce 채널 초기화 비용 때문으로 보인다(2~3회차부터 안정화).
-- **추가 개선 여지(이번 범위 밖, 발견한 개선점으로만 기록)**: DB 쪽이 이제 지배적인 비용이므로, 여기서 더 줄이려면 `UPDATE ... FROM (VALUES ...)` 형태의 멀티로우 배치 UPDATE로 청크당 DB 왕복을 1,000회에서 1회로 줄이는 방안을 고려할 수 있다. 다만 이 프로젝트의 실제 스케줄 주기(10분)와 트래픽 규모를 감안하면 지금 소요 시간(수 초)도 사용자 응답 경로와 무관한 백그라운드 작업이라 체감 영향이 없어, 우선순위는 낮다고 판단한다.
+- **추가 개선 여지(당시엔 범위 밖으로 남겼음, 아래 절에서 실제로 적용함)**: DB 쪽이 이제 지배적인 비용이므로, 여기서 더 줄이려면 `UPDATE ... FROM (VALUES ...)` 형태의 멀티로우 배치 UPDATE로 청크당 DB 왕복을 1,000회에서 1회로 줄이는 방안을 고려할 수 있다.
+
+---
+
+## ✅ 후속 결정: 청크당 DB 왕복을 네이티브 멀티로우 UPDATE로 1회로 통합
+
+[이슈 #65](https://github.com/Kookmin-MoP-Yourtrip/YOURTRIP_BE/issues/65)에서 위 "추가 개선 여지"를 실제로 적용했다.
+
+### 왜 `hibernate.jdbc.batch_size`가 아니었는가
+
+가장 먼저 검토한 건 Hibernate의 `hibernate.jdbc.batch_size` 설정이었다. 하지만 이 설정은 **영속성 컨텍스트의 dirty-checking flush**(즉 `save()`/`persist()`로 관리되는 엔티티가 flush될 때 자동 생성되는 DML)에만 적용된다. `incrementViewCount`는 `@Modifying @Query`로 짠 커스텀 벌크 쿼리라 호출 즉시 `executeUpdate()`가 실행되며 flush 파이프라인을 거치지 않으므로, 이 설정을 켜도 지금 패턴에는 효과가 없다. 대안으로 "엔티티를 로드해서 수정 후 `saveAll`" 방식으로 전환하는 것도 검토했으나, 이 경우에도 왕복 횟수는 `N/batch_size`로 줄어들 뿐 "1회 보장"은 되지 않고, `order_updates` 설정이 빠지면 조용히 배치가 무효화되는 리스크가 있어 채택하지 않았다.
+
+### 채택한 방식
+
+[UploadCourseRepository.java](../../src/main/java/backend/yourtrip/domain/uploadcourse/repository/UploadCourseRepository.java)에 Postgres `unnest()`로 두 병렬 배열(ids, increments)을 행 집합으로 풀어 조인하는 네이티브 멀티로우 UPDATE를 추가했다:
+
+```sql
+UPDATE upload_course uc
+SET view_count = uc.view_count + v.increment
+FROM (SELECT unnest(:ids) AS id, unnest(:increments) AS increment) AS v
+WHERE uc.upload_course_id = v.id
+```
+
+`UploadCourseService.applyViewCountIncrements`는 이제 청크 엔트리를 순회하는 루프 대신 이 쿼리를 1회 호출한다. 기존 단건 `incrementViewCount(id, increment)`는 호출부가 없어져 완전히 제거했다.
+
+### 재측정 (대상 코스 10,000건, 동일 방법론)
+
+| 지표 | Before (개별 UPDATE 루프) | After (멀티로우 UPDATE) | 개선 |
+|---|---|---|---|
+| 청크당 DB 왕복 횟수(이론치) | 1,000회 | 1회 | 1,000배 감소 |
+| 소요 시간 1회차 | 6,932 ms | 2,293 ms | - |
+| 소요 시간 2회차 | 4,916 ms | 1,614 ms | - |
+| 소요 시간 3회차 | 3,813 ms | 2,042 ms | - |
+| **중앙값** | **4,916 ms** | **2,042 ms** | **약 2.4배 (58% 단축)** |
+
+`hibernate.SQL: debug` 로그로도 청크당 `UPDATE upload_course` 문장이 정확히 1번만 실행됨을 확인했다(기존에는 1,000번).
+
+### 결과 해석
+
+- DB 왕복은 이론상 1,000배 줄었는데 전체 소요 시간은 2.4배 개선에 그쳤다. Redis 파이프라이닝 때와 같은 패턴이다 — 왕복 횟수 감소가 곧바로 같은 배수의 시간 단축으로 이어지지 않는다. Postgres 입장에서 "행 1,000개를 개별 UPDATE 1,000번"과 "행 1,000개를 멀티로우 UPDATE 1번"은 네트워크 왕복 수는 크게 다르지만, DB 서버 내부에서 실제로 1,000개 행을 찾아 잠그고 갱신하는 작업량 자체는 비슷하기 때문으로 보인다. 즉 이번 최적화로 없앤 건 "네트워크 RTT 누적 비용"이지 "행 갱신 자체의 비용"이 아니다.
+- 그럼에도 이 최적화의 핵심 가치는 절대 시간 단축보다 **커넥션 점유 시간 단축**에 있다. 기존에는 청크 하나를 처리하는 동안 HikariCP 커넥션 하나를 1,000번의 순차 왕복 내내(수 초) 붙잡고 있었는데, 이제는 SQL 한 문장을 보내고 응답을 기다리는 훨씬 짧은 시간만 붙잡는다. 실제 트래픽과 겹칠 때 커넥션 풀 경합 위험을 줄인다는 점에서, 이번 변경은 "스케줄러를 더 빠르게" 만들었다기보다 "스케줄러가 다른 요청에 주는 부담을 줄였다"는 관점에서 더 의미가 있다.

--- a/docs/tasks/TASK-5.md
+++ b/docs/tasks/TASK-5.md
@@ -131,3 +131,23 @@ sequenceDiagram
 - `UploadCourseViewCountService.readPendingIncrements` / `clearSyncedIncrements` — 파이프라인 GET/DECRBY
 - `UploadCourseService.applyViewCountIncrements` — 청크별 독립 트랜잭션 커밋
 - `ViewCountSyncScheduler.syncChunk` — 청크 분할 및 GET → DB 커밋 → DECRBY 순서 오케스트레이션
+
+---
+
+## 📊 Before/After 성능 실측 (대상 코스 10,000건)
+
+`@SpringBootTest` 기반 임시 벤치마크로 `syncViewCountsToDb()` 단독 호출 구간의 소요 시간을 측정했다(HTTP API가 아닌 스케줄러 내부 메서드라 TASK-3/4의 Node.js 부하 스크립트 방식은 적용 불가 — 대신 정합성 검증에 쓴 것과 동일한 `@SpringBootTest` + 스톱워치 패턴 재사용). 실제 로컬 Redis(Docker)·Postgres에 코스 10,000건, 코스당 증분 3을 시딩하고 3회씩 반복 측정했다.
+
+| 지표 | Before (GETDEL 순차) | After (GET+DECRBY 청크 파이프라이닝) | 개선 |
+|---|---|---|---|
+| Redis 왕복 횟수(이론치) | 10,000회 (코스당 1회) | 40회 (20청크 × GET/DECRBY 각 1회) | 약 250배 감소 |
+| 소요 시간 1회차 | 14,817 ms | 6,333 ms | - |
+| 소요 시간 2회차 | 11,462 ms | 4,204 ms | - |
+| 소요 시간 3회차 | 11,070 ms | 3,797 ms | - |
+| **중앙값** | **11,462 ms** | **4,204 ms** | **약 2.7배 (63% 단축)** |
+
+### 결과 해석
+
+- Redis 왕복 횟수는 이론상 250배(10,000 → 40) 줄었지만, 실제 소요 시간 개선은 2.7배에 그쳤다. 원인은 명확하다 — **DB 왕복 횟수가 Before/After 동일**하기 때문이다. `applyViewCountIncrements`도 결국 `incrementViewCount(id, increment)`를 코스마다 한 번씩 개별 호출하는 구조라(멀티로우 배치 SQL이 아님), DB 쪽은 여전히 10,000회 왕복이 발생한다. 이번 변경은 "Redis 구간"만 최적화한 것이고, 측정 결과가 그 사실을 정확히 보여준다.
+- 1회차가 항상 2~3회차보다 느린 것은 JIT 워밍업, 커넥션 풀·Lettuce 채널 초기화 비용 때문으로 보인다(2~3회차부터 안정화).
+- **추가 개선 여지(이번 범위 밖, 발견한 개선점으로만 기록)**: DB 쪽이 이제 지배적인 비용이므로, 여기서 더 줄이려면 `UPDATE ... FROM (VALUES ...)` 형태의 멀티로우 배치 UPDATE로 청크당 DB 왕복을 1,000회에서 1회로 줄이는 방안을 고려할 수 있다. 다만 이 프로젝트의 실제 스케줄 주기(10분)와 트래픽 규모를 감안하면 지금 소요 시간(수 초)도 사용자 응답 경로와 무관한 백그라운드 작업이라 체감 영향이 없어, 우선순위는 낮다고 판단한다.

--- a/docs/tasks/TASK-5.md
+++ b/docs/tasks/TASK-5.md
@@ -31,14 +31,19 @@
    - *이점*: 동기화 처리 중에 새롭게 유입되는 조회수 요청은 새로운 `view_count_dirty` Set에 쌓이게 되므로, 동시성 데이터 유실이나 락 경합이 발생하지 않습니다.
 4. **대상 코스 ID 목록 조회 (`SMEMBERS`)**
    - `SMEMBERS snapshotKey` 명령어로 동기화 대상이 되는 코스 ID 목록 전체를 가져옵니다.
-5. **원자적 증분값 추출 및 키 삭제 (`GETDEL`)**
-   - 가져온 코스 ID를 순회하며 순정 `GETDEL` 커맨드(`opsForValue().getAndDelete(counterKey)`)를 실행합니다.
-   - 카운팅된 조회수 증분값을 원자적으로 읽어옴과 동시에 Redis에서 해당 카운터 키를 즉시 삭제합니다.
-6. **DB 벌크 증분 반영 (`UPDATE`)**
-   - 읽어온 증분값이 0보다 큰 경우, `UploadCourseRepository.incrementViewCount(uploadCourseId, increment)`를 통해 DB에 `UPDATE UploadCourse SET viewCount = viewCount + :increment WHERE id = :id` 쿼리를 실행합니다.
-7. **스냅샷 정리 및 랭킹 캐시 갱신 (Refresh-Ahead)**
-   - 처리 완료 후 스냅샷 키를 삭제합니다.
+5. **청크 분할 및 파이프라인 읽기 (`GET`)**
+   - 대상 ID를 1,000개 단위 청크로 나눕니다(`ViewCountSyncScheduler.SYNC_CHUNK_SIZE`).
+   - 청크마다 `UploadCourseViewCountService.readPendingIncrements`가 `executePipelined`로 `GET view_count:increment:{id}`를 한 번의 왕복에 묶어 실행합니다. **GETDEL이 아닌 GET**이므로 이 시점에는 Redis 카운터가 지워지지 않습니다.
+6. **청크별 독립 트랜잭션으로 DB 반영 (`UPDATE`)**
+   - 읽어온 증분이 있으면 `UploadCourseService.applyViewCountIncrements(increments)`를 호출합니다. 이 메서드에만 `@Transactional`이 걸려 있어, 호출이 끝나는 시점에 그 청크의 `UPDATE UploadCourse SET viewCount = viewCount + :increment WHERE id = :id`가 독립적으로 커밋됩니다.
+7. **커밋 확인 후 파이프라인 차감 (`DECRBY`)**
+   - DB 커밋이 끝난 뒤에만 `UploadCourseViewCountService.clearSyncedIncrements`가 방금 읽은 값만큼 `DECRBY`를 파이프라인으로 실행합니다. `DEL`이 아니라 `DECRBY`를 쓰는 이유는 그 사이 새로 들어온 조회 증분을 보존하기 위해서입니다.
+   - 한 청크가 실패해도 예외를 격리하고 다음 청크로 진행합니다. 실패한 청크는 DECRBY가 실행되지 않으므로 그 증분은 Redis에 남아 다음 조회 시 자연스럽게 재동기화됩니다(유실이 아니라 지연).
+8. **스냅샷 정리 및 랭킹 캐시 갱신 (Refresh-Ahead)**
+   - 모든 청크 처리 후 스냅샷 키를 삭제합니다.
    - DB의 조회수가 최신화되었으므로, `uploadCourseService.refreshAllPopularCoursesCache()`를 호출해 인기 코스 Top 5 랭킹 캐시를 최신 상태로 덮어씁니다(Refresh-Ahead).
+
+> GETDEL 순차 처리에서 GET→DECRBY 2단계 + 청크 파이프라이닝으로 전환한 배경과 근거는 아래 [발견한 개선점 및 트레이드오프 분석](#-발견한-개선점-및-트레이드오프-분석) 섹션 참고.
 
 ---
 
@@ -61,11 +66,13 @@ sequenceDiagram
         Scheduler->>Redis: RENAME view_count_dirty snapshotKey
         Scheduler->>Redis: SMEMBERS snapshotKey
         Redis-->>Scheduler: [id1, id2, ...]
-        loop 코스 ID 단위 순회
-            Scheduler->>Redis: GETDEL view_count:increment:{id}
-            Redis-->>Scheduler: 증분값
+        loop 1,000개 단위 청크
+            Scheduler->>Redis: 파이프라인 GET view_count:increment:{id} (N건 묶음, 삭제 안 함)
+            Redis-->>Scheduler: 증분값 목록
+            Scheduler->>DB: 청크 전용 트랜잭션으로 Bulk UPDATE viewCount
+            DB-->>Scheduler: 커밋 완료
+            Scheduler->>Redis: 파이프라인 DECRBY view_count:increment:{id} (커밋 확인 후에만)
         end
-        Scheduler->>DB: Bulk UPDATE viewCount
         Scheduler->>Redis: DEL snapshotKey
         Scheduler->>API: refreshAllPopularCoursesCache()
     end
@@ -93,3 +100,34 @@ sequenceDiagram
 
 **결론 및 추후 최적화 대안 (Chunking):**
 백그라운드 동기화 스케줄러는 RTT 단축보다 **데이터 유실 방지(안정성)**가 훨씬 중요한 도메인입니다. 무작정 파이프라이닝으로 밀어넣는 것은 데이터 유실 위험이 크므로, 만약 속도 개선이 필요하다면 **100~500개 단위의 청크(Chunk)로 쪼개어 파이프라이닝과 DB 벌크 업데이트를 수행하는 방식**을 도입하여 리스크를 최소화하는 것이 좋습니다.
+
+---
+
+## ✅ 최종 결정: GET→DECRBY 2단계 + 청크 파이프라이닝 + 청크별 트랜잭션 분리
+
+위 분석 이후 실무 사례를 추가로 조사하고([참고: GitLab `BufferedCounter`](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/104936), [Redis 공식 파이프라이닝 문서](https://redis.io/docs/latest/develop/using-commands/pipelining/)), 다음 두 가지를 재검토해 최종 구현 방향을 확정했습니다.
+
+### 기존 분석에서 보완/반박된 지점
+
+1. **청크 크기의 근거를 "성능"이 아니라 "유실 상한 제한"으로 바꿨습니다.** Redis 공식 문서는 파이프라인 청크를 10,000개 단위로 권장하며, GETDEL 응답처럼 수 바이트짜리 값이면 클라이언트 메모리 부하도 실질적으로 미미합니다. 즉 100~500개라는 청크 크기를 "성능/메모리" 근거로 정당화하기는 어렵습니다. 대신 **"청크는 유실을 없애는 게 아니라 크래시 시 유실(또는 지연) 범위를 그 청크 크기만큼으로 제한하는 장치"**라는 점을 명확히 하고, 청크 크기는 1,000으로 조정했습니다.
+2. **"청크로 쪼개면 유실이 안전해진다"는 명제 자체가 성립하지 않는다는 점을 확인했습니다.** GETDEL을 유지하는 한, 청크 크기와 무관하게 크래시 시점의 그 청크는 Redis에서는 이미 지워졌지만 DB 트랜잭션은 커밋되지 않아 그대로 유실됩니다. 유실을 **제거**하려면 청크 분할이 아니라 "삭제 시점을 DB 커밋 이후로 미루는 것" 자체가 필요합니다.
+
+### 채택한 방식
+
+- **`GETDEL` → `GET`(비파괴적 읽기) + `DECRBY`(보상 차감) 2단계로 전환**: Redis에서 즉시 확정적으로 지워지는 GETDEL 대신, 값을 읽기만 하고 DB 반영이 실제로 커밋된 뒤에만 그만큼을 차감합니다. `DEL`이 아니라 `DECRBY`를 쓰는 이유는, 그 사이 새로 들어온 조회 증분까지 함께 지워지는 것을 막기 위해서입니다(`DEL`을 쓰면 동시 INCR분이 조용히 사라집니다).
+- **청크(1,000개) 단위 파이프라이닝**: `GET`과 `DECRBY` 각각을 청크 단위로 한 번의 네트워크 왕복에 묶어 처리합니다.
+- **청크별 독립 트랜잭션 커밋**: 스케줄러 메서드 전체에 걸려 있던 `@Transactional`을 제거하고, 청크의 DB 반영을 별도 서비스 메서드(`UploadCourseService.applyViewCountIncrements`)로 분리해 그 메서드에만 `@Transactional`을 걸었습니다. 이렇게 해야 "그 청크의 DB 반영이 실제로 커밋된 뒤에만 DECRBY를 호출한다"는 순서가 보장됩니다 — 스케줄러 메서드를 통째로 트랜잭션으로 감싼 채로는 GET→DECRBY로 바꿔도 여전히 동일한 유실 창구가 재현됩니다.
+
+### 트레이드오프
+
+- 유실은 없어졌지만, DB 커밋 이후 DECRBY 실행 전에 스케줄러가 크래시하면 다음 주기에 같은 증분이 한 번 더 반영되는 **중복(과대 집계)** 가능성은 남습니다. 조회수는 정확히 맞을 필요가 없는 지표이므로, 유실(과소 집계)보다 이 쪽이 훨씬 저렴한 대가라고 판단했습니다.
+- 한 청크가 DB 오류 등으로 실패해도 예외를 격리해 다음 청크로 계속 진행하며, 실패한 청크의 증분은 Redis에 남아 다음 조회 시 자연스럽게 재동기화됩니다(유실이 아니라 지연).
+- **`GETDEL` 대비 새로 생긴 부작용 — 카운터 키가 삭제되지 않고 영구히 남음**: 실제 Redis/DB로 검증하는 과정에서 확인한 부분입니다. `DECRBY`는 값을 0으로 만들 뿐 키 자체를 지우지 않으므로, 한 번이라도 조회된 코스는 `view_count:increment:{id}` 키가 값 `0`인 채로 Redis에 영구히 남습니다(예전 `GETDEL`은 처리 후 키를 완전히 지웠습니다). `readPendingIncrements`가 0 이하 값을 걸러내므로 다음 동기화 대상에는 포함되지 않아 기능적으로는 무해하지만, 키 자체는 계속 존재합니다.
+  - 이 프로젝트에서는 채택하지 않은 이유: 키 개수의 상한이 "역대 조회된 적 있는 코스 수"로 자연히 제한되고(유저 수·요청 수가 아니라 콘텐츠 수에 비례), 콘텐츠는 사람이 직접 만들어 업로드하는 만큼 규모가 크지 않아 메모리 영향이 무시할 수준입니다.
+  - 완전히 없애려면 `DECRBY` 후 결과값이 0 이하일 때 `DEL`까지 원자적으로 수행하는 Lua 스크립트(`DECRBY`→조건부 `DEL`)를 파이프라인 안에서 실행하는 방법이 있지만, 이 정도 규모에서는 추가 복잡도 대비 이득이 작다고 판단해 채택하지 않았습니다.
+
+### 구현 위치
+
+- `UploadCourseViewCountService.readPendingIncrements` / `clearSyncedIncrements` — 파이프라인 GET/DECRBY
+- `UploadCourseService.applyViewCountIncrements` — 청크별 독립 트랜잭션 커밋
+- `ViewCountSyncScheduler.syncChunk` — 청크 분할 및 GET → DB 커밋 → DECRBY 순서 오케스트레이션

--- a/src/main/java/backend/yourtrip/domain/uploadcourse/repository/UploadCourseRepository.java
+++ b/src/main/java/backend/yourtrip/domain/uploadcourse/repository/UploadCourseRepository.java
@@ -108,7 +108,16 @@ public interface UploadCourseRepository extends JpaRepository<UploadCourse, Long
         """)
     List<UploadCourse> findAllByIdInWithKeywords(@Param("ids") List<Long> ids);
 
+    /**
+     * 청크 전체(최대 1,000건)의 증분을 SQL 한 문장으로 반영해 DB 왕복을 청크당 1회로 보장한다.
+     * ids/increments는 병렬 배열(같은 인덱스가 한 코스의 id/증분 쌍)로 unnest()해 조인한다.
+     */
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE UploadCourse uc SET uc.viewCount = uc.viewCount + :increment WHERE uc.id = :id")
-    void incrementViewCount(@Param("id") Long id, @Param("increment") long increment);
+    @Query(value = """
+        UPDATE upload_course uc
+        SET view_count = uc.view_count + v.increment
+        FROM (SELECT unnest(:ids) AS id, unnest(:increments) AS increment) AS v
+        WHERE uc.upload_course_id = v.id
+        """, nativeQuery = true)
+    void incrementViewCounts(@Param("ids") Long[] ids, @Param("increments") Long[] increments);
 }

--- a/src/main/java/backend/yourtrip/domain/uploadcourse/scheduler/ViewCountSyncScheduler.java
+++ b/src/main/java/backend/yourtrip/domain/uploadcourse/scheduler/ViewCountSyncScheduler.java
@@ -1,6 +1,5 @@
 package backend.yourtrip.domain.uploadcourse.scheduler;
 
-import backend.yourtrip.domain.uploadcourse.repository.UploadCourseRepository;
 import backend.yourtrip.domain.uploadcourse.service.UploadCourseService;
 import backend.yourtrip.domain.uploadcourse.service.UploadCourseViewCountService;
 import lombok.RequiredArgsConstructor;
@@ -8,8 +7,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
@@ -18,12 +19,16 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class ViewCountSyncScheduler {
 
+    // Redis GET/DECRBY 파이프라인 1회에 묶는 코스 ID 수. 성능(왕복 절감) 목적과 함께, 크래시 시
+    // 유실이 아니라 "지연"으로 그치는 상한을 이 값으로 제한하는 정합성 목적도 겸한다.
+    // 자세한 트레이드오프 분석은 docs/tasks/TASK-5.md 참고.
+    private static final int SYNC_CHUNK_SIZE = 1000;
+
     private final RedisTemplate<String, String> redisTemplate;
-    private final UploadCourseRepository uploadCourseRepository;
+    private final UploadCourseViewCountService uploadCourseViewCountService;
     private final UploadCourseService uploadCourseService;
 
     @Scheduled(cron = "0 0/10 * * * *") // 매 10분마다 실행
-    @Transactional
     public void syncViewCountsToDb() {
         String snapshotKey = UploadCourseViewCountService.VIEW_COUNT_DIRTY_SET_KEY + "_snapshot_" + UUID.randomUUID();
 
@@ -32,7 +37,7 @@ public class ViewCountSyncScheduler {
             if (!Boolean.TRUE.equals(hasKey)) {
                 return; // 변경된 코스가 없음
             }
-            
+
             try {
                 // RENAME을 통해 현재 모인 dirty 목록을 스냅샷으로 격리 (신규 유입과 분리)
                 redisTemplate.rename(UploadCourseViewCountService.VIEW_COUNT_DIRTY_SET_KEY, snapshotKey);
@@ -47,17 +52,10 @@ public class ViewCountSyncScheduler {
                 return;
             }
 
-            for (String courseIdStr : dirtyCourseIds) {
-                String counterKey = UploadCourseViewCountService.VIEW_COUNT_INCREMENT_KEY_PREFIX + courseIdStr;
-                String incrementStr = redisTemplate.opsForValue().getAndDelete(counterKey);
-
-                if (incrementStr != null) {
-                    long increment = Long.parseLong(incrementStr);
-                    if (increment > 0) {
-                        Long uploadCourseId = Long.parseLong(courseIdStr);
-                        uploadCourseRepository.incrementViewCount(uploadCourseId, increment);
-                    }
-                }
+            List<Long> courseIds = dirtyCourseIds.stream().map(Long::parseLong).toList();
+            int syncedCount = 0;
+            for (List<Long> chunk : partition(courseIds, SYNC_CHUNK_SIZE)) {
+                syncedCount += syncChunk(chunk);
             }
 
             // DB 업데이트 후 스냅샷 삭제
@@ -66,9 +64,43 @@ public class ViewCountSyncScheduler {
             // DB에 인기 코스 순위 변동이 반영되었으므로, 캐시를 갱신한다 (Refresh-Ahead)
             uploadCourseService.refreshAllPopularCoursesCache();
 
-            log.info("조회수 동기화 및 랭킹 갱신 완료. 갱신된 코스 수: {}", dirtyCourseIds.size());
+            log.info("조회수 동기화 및 랭킹 갱신 완료. 대상 코스 수: {}, 반영된 코스 수: {}",
+                dirtyCourseIds.size(), syncedCount);
         } catch (Exception e) {
             log.error("조회수 동기화 스케줄러 실행 중 오류 발생", e);
         }
+    }
+
+    /**
+     * 청크 하나를 GET(파이프라인) → DB 커밋 → DECRBY(파이프라인) 순서로 처리한다.
+     * 청크 단위로 예외를 격리해, 한 청크가 실패해도 나머지 청크는 계속 진행한다. 실패한 청크는
+     * DECRBY를 호출하지 않으므로 그 증분은 Redis에 그대로 남아, 다음에 해당 코스가 다시 조회되면
+     * 자연스럽게 재동기화된다(유실이 아니라 지연).
+     */
+    private int syncChunk(List<Long> chunk) {
+        try {
+            Map<Long, Long> increments = uploadCourseViewCountService.readPendingIncrements(chunk);
+            if (increments.isEmpty()) {
+                return 0;
+            }
+
+            // 이 호출이 반환되는 시점에 이 청크의 DB 트랜잭션이 독립적으로 커밋된다.
+            uploadCourseService.applyViewCountIncrements(increments);
+
+            // DB 커밋이 확정된 뒤에만 Redis 카운터를 차감한다.
+            uploadCourseViewCountService.clearSyncedIncrements(increments);
+            return increments.size();
+        } catch (Exception e) {
+            log.error("조회수 동기화 청크 처리 중 오류 발생. chunkSize={}", chunk.size(), e);
+            return 0;
+        }
+    }
+
+    private static List<List<Long>> partition(List<Long> ids, int chunkSize) {
+        List<List<Long>> chunks = new ArrayList<>();
+        for (int i = 0; i < ids.size(); i += chunkSize) {
+            chunks.add(ids.subList(i, Math.min(i + chunkSize, ids.size())));
+        }
+        return chunks;
     }
 }

--- a/src/main/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseService.java
+++ b/src/main/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseService.java
@@ -9,6 +9,7 @@ import backend.yourtrip.domain.uploadcourse.dto.response.UploadCourseListRespons
 import backend.yourtrip.domain.uploadcourse.entity.enums.KeywordType;
 import backend.yourtrip.domain.uploadcourse.entity.enums.UploadCourseSortType;
 import java.util.List;
+import java.util.Map;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface UploadCourseService {
@@ -32,4 +33,10 @@ public interface UploadCourseService {
         List<MultipartFile> placeImages);
 
     void refreshAllPopularCoursesCache();
+
+    /**
+     * 조회수 동기화 스케줄러가 청크 단위로 호출한다. 이 메서드가 반환되는 시점에 해당 청크의
+     * DB 트랜잭션이 독립적으로 커밋되어야, 호출부가 커밋 확인 후에만 Redis 카운터를 차감할 수 있다.
+     */
+    void applyViewCountIncrements(Map<Long, Long> increments);
 }

--- a/src/main/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseServiceImpl.java
+++ b/src/main/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseServiceImpl.java
@@ -780,4 +780,17 @@ public class UploadCourseServiceImpl implements UploadCourseService {
             computePopularCourseIdsWithLock(theme, theme.name());
         }
     }
+
+    /**
+     * ViewCountSyncScheduler가 청크(예: 1,000건)마다 이 메서드를 호출한다. 스케줄러 메서드 자체는
+     * @Transactional이 아니므로, 청크마다 이 호출이 끝나는 시점에 그 청크만의 트랜잭션이 독립적으로
+     * 커밋된다 — 스케줄러가 커밋 확정 이후에만 Redis DECRBY를 내보낼 수 있는 전제가 여기서 만들어진다.
+     */
+    @Override
+    @Transactional
+    public void applyViewCountIncrements(Map<Long, Long> increments) {
+        for (Map.Entry<Long, Long> entry : increments.entrySet()) {
+            uploadCourseRepository.incrementViewCount(entry.getKey(), entry.getValue());
+        }
+    }
 }

--- a/src/main/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseServiceImpl.java
+++ b/src/main/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseServiceImpl.java
@@ -40,6 +40,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -789,8 +790,9 @@ public class UploadCourseServiceImpl implements UploadCourseService {
     @Override
     @Transactional
     public void applyViewCountIncrements(Map<Long, Long> increments) {
-        for (Map.Entry<Long, Long> entry : increments.entrySet()) {
-            uploadCourseRepository.incrementViewCount(entry.getKey(), entry.getValue());
-        }
+        List<Long> ids = new ArrayList<>(increments.keySet());
+        Long[] idArray = ids.toArray(new Long[0]);
+        Long[] incrementArray = ids.stream().map(increments::get).toArray(Long[]::new);
+        uploadCourseRepository.incrementViewCounts(idArray, incrementArray);
     }
 }

--- a/src/main/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseViewCountService.java
+++ b/src/main/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseViewCountService.java
@@ -2,10 +2,14 @@ package backend.yourtrip.domain.uploadcourse.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -26,5 +30,58 @@ public class UploadCourseViewCountService {
             // Redis 장애 격리 (fail-open)
             log.warn("Redis 조회수 카운터 증가 실패. uploadCourseId={}", uploadCourseId, e);
         }
+    }
+
+    /**
+     * 청크 단위로 조회수 증분을 파이프라인 GET으로 한 번에 읽어온다. GETDEL과 달리 값을 지우지 않으므로,
+     * 이 시점에는 DB 반영이 아직 확정되지 않았어도 안전하다 — 삭제는 DB 커밋이 끝난 뒤
+     * clearSyncedIncrements()가 별도로 담당한다.
+     */
+    public Map<Long, Long> readPendingIncrements(List<Long> courseIds) {
+        if (courseIds.isEmpty()) {
+            return Map.of();
+        }
+
+        List<Object> results = redisTemplate.executePipelined((RedisCallback<Object>) connection -> {
+            for (Long courseId : courseIds) {
+                connection.stringCommands().get(counterKeyBytes(courseId));
+            }
+            return null;
+        });
+
+        Map<Long, Long> increments = new LinkedHashMap<>();
+        for (int i = 0; i < courseIds.size(); i++) {
+            String rawValue = (String) results.get(i);
+            if (rawValue == null) {
+                continue;
+            }
+            long increment = Long.parseLong(rawValue);
+            if (increment > 0) {
+                increments.put(courseIds.get(i), increment);
+            }
+        }
+        return increments;
+    }
+
+    /**
+     * DB 커밋이 끝난 뒤에만 호출해야 한다. 읽어온 값만큼만 DECRBY로 차감해, 그 사이 새로 유입된
+     * 조회 증분(다음 주기 dirty set에는 잡히지만 아직 이 카운터 값에 합산된 부분)을 보존한다.
+     * DEL을 쓰면 동시에 들어온 증분까지 통째로 지워져 조용히 유실되므로 반드시 DECRBY여야 한다.
+     */
+    public void clearSyncedIncrements(Map<Long, Long> increments) {
+        if (increments.isEmpty()) {
+            return;
+        }
+
+        redisTemplate.executePipelined((RedisCallback<Object>) connection -> {
+            for (Map.Entry<Long, Long> entry : increments.entrySet()) {
+                connection.stringCommands().decrBy(counterKeyBytes(entry.getKey()), entry.getValue());
+            }
+            return null;
+        });
+    }
+
+    private byte[] counterKeyBytes(Long courseId) {
+        return (VIEW_COUNT_INCREMENT_KEY_PREFIX + courseId).getBytes(StandardCharsets.UTF_8);
     }
 }


### PR DESCRIPTION
## ✅ 작업 내용

### GETDEL 순차 처리를 GET→DECRBY 청크 파이프라이닝으로 전환
- 조회수 동기화 스케줄러가 대상 코스 ID를 1,000개 단위 청크로 나눠, 청크마다 파이프라이닝으로 Redis 왕복 횟수를 줄일 수 있다
- `GETDEL`(즉시 확정적으로 삭제) 대신 `GET`(비파괴적 읽기) 후 DB 커밋이 확정된 뒤에만 `DECRBY`(보상 차감)를 실행해, 처리 도중 서버가 크래시해도 조회수 증분이 유실되지 않는다
- 청크별로 독립된 트랜잭션(`UploadCourseService.applyViewCountIncrements`)으로 커밋해, "DB 반영이 실제로 끝난 뒤에만 Redis 카운터를 지운다"는 순서를 보장한다
- 한 청크가 실패해도 예외를 격리해 다음 청크로 계속 진행하며, 실패한 청크의 증분은 유실 없이 다음 조회 시 자연스럽게 재동기화된다
- 대상 코스 10,000건 기준 실측: Redis 왕복 10,000회→40회, 소요 시간 중앙값 11,462ms→4,204ms(약 2.7배)

### 청크당 DB 왕복을 네이티브 멀티로우 UPDATE로 통합
- 위 파이프라이닝 적용 후에도 `applyViewCountIncrements`가 청크 엔트리마다 개별 `UPDATE`를 호출해, 트랜잭션 하나가 최대 1,000번의 순차 DB 왕복을 발생시키고 그동안 커넥션 하나를 계속 점유하는 문제가 남아있었다
- `hibernate.jdbc.batch_size`는 `@Modifying` 커스텀 벌크 쿼리에는 적용되지 않아 검토 후 배제하고, Postgres `unnest()` 기반 네이티브 멀티로우 `UPDATE ... FROM (VALUES ...)` 한 문장으로 청크 전체를 반영하도록 바꿔 왕복을 1회로 보장했다
- 대상 코스 10,000건 기준 실측: 소요 시간 중앙값 4,916ms→2,042ms(약 2.4배) — 절대 시간 단축보다 커넥션 점유 시간을 크게 줄인 데 의미가 있다

### 문서화
- 실무 사례 리서치 근거, 최종 결정 사항, 실제 Redis/DB로 검증하며 발견한 트레이드오프(예: `DECRBY`로 인해 0값 카운터 키가 삭제되지 않고 남는 현상과 그 대응 방안), 두 차례의 Before/After 실측 결과를 `TASK-5.md`에 기록했다

## 📌 관련 이슈

closes #63
closes #65

## 📚 추가 리팩토링 가능성

- `ViewCountSyncScheduler`/`UploadCourseViewCountService`/`UploadCourseRepository`에 대한 단위·통합 테스트가 아직 없다. 실제 Redis/DB를 붙여 검증하는 임시 테스트로 동작을 확인했지만, 회귀 방지를 위한 영구 테스트로 남기는 것을 고려할 만하다.
- `DECRBY`로 인해 한 번이라도 조회된 코스의 카운터 키가 0 값으로 Redis에 영구히 남는다. 현재 규모(코스 수에 비례하는 바운디드 카운트)에서는 메모리 영향이 무시할 수준이라 채택하지 않았지만, 필요해지면 `DECRBY` + 조건부 `DEL`을 원자적으로 묶는 Lua 스크립트로 정리할 수 있다(대안은 TASK-5.md에 기록).
- 다중 파드 환경에서의 스케줄러 중복 실행 방지(분산 락)는 현재 단일 인스턴스 가정이라 범위 밖으로 남겨뒀다.