### PR TITLE
feat: 업로드 코스 수정 API 캐시 write-through 무효화 로직 추가

### DIFF
--- a/src/main/java/backend/yourtrip/domain/uploadcourse/event/UploadCourseCacheRefreshEvent.java
+++ b/src/main/java/backend/yourtrip/domain/uploadcourse/event/UploadCourseCacheRefreshEvent.java
@@ -1,0 +1,17 @@
+package backend.yourtrip.domain.uploadcourse.event;
+
+import backend.yourtrip.domain.uploadcourse.dto.cache.CourseListItemCacheItem;
+import backend.yourtrip.domain.uploadcourse.dto.cache.UploadCourseDetailCacheItem;
+
+/**
+ * 업로드 코스 수정 트랜잭션이 커밋된 뒤 courseDetail/courseListItem 캐시를 write-through로
+ * 갱신하기 위한 이벤트. 커밋 전(영속성 컨텍스트가 살아있는) 시점에 이미 조립해둔 캐시 DTO를
+ * 그대로 담아, 커밋 이후 실행되는 리스너가 엔티티에 다시 접근하지 않고 캐시 쓰기만 수행하도록 한다.
+ */
+public record UploadCourseCacheRefreshEvent(
+    Long uploadCourseId,
+    UploadCourseDetailCacheItem detailCacheItem,
+    CourseListItemCacheItem listItemCacheItem
+) {
+
+}

--- a/src/main/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseServiceImpl.java
+++ b/src/main/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseServiceImpl.java
@@ -504,12 +504,11 @@ public class UploadCourseServiceImpl implements UploadCourseService {
     // IllegalStateException을 던진다(실측 확인, cacheSerializer() 주석 참고). courseListItem과
     // 동일하게 타입을 명시한 Jackson2JsonRedisSerializer로 원시 Redis 커맨드를 직접 다룬다.
     //
-    // TTL은 courseListItem과 동일하게 RedisConfig.COURSE_LIST_ITEM_TTL(2시간)을 그대로 재사용한다.
-    // 처음엔 5분으로 잡았으나, 상세 캐시가 담는 필드(title/location/thumbnail/forkCount/keywords + 일정)가
-    // courseListItem이 담는 필드와 변경 빈도 면에서 다를 게 없다는 점(업로드 후 수정 API가 없어 사실상
-    // 정적이고, 유일하게 바뀌는 forkCount는 6-2에서 evict로 별도 처리될 예정)을 재검토해 늘렸다.
-    // 5분은 이 콘텐츠의 실제 변경 빈도에 비해 과도하게 짧아 DB 부하 절감 효과를 스스로 깎아먹고
-    // 있었다 — TTL은 데이터 변경 빈도에 맞춰야 한다는 일반적인 캐싱 원칙에 따른 조정이다.
+    // TTL은 RedisConfig.COURSE_DETAIL_TTL(2시간)을 쓴다. courseListItem과 같은 2시간이지만 별도
+    // 상수다 — 두 캐시가 담는 필드의 변경 빈도가 우연히 같을 뿐, 정합성 정책이 묶여 있는 건 아니다.
+    // 콘텐츠가 실제로 바뀌는 시점(updateUploadCourse)의 정합성은 이 TTL이 아니라 커밋 후
+    // write-through(아래 4단계 섹션의 refreshUploadCourseCaches)로 보장하며, TTL은 그 write-through가
+    // Redis 장애 등으로 누락됐을 때의 안전망 역할만 한다.
 
     /**
      * 랭킹/아이템 캐시와 동일하게 jitter나 락 없이 단순 cache-aside로 구현한다.
@@ -539,7 +538,7 @@ public class UploadCourseServiceImpl implements UploadCourseService {
             byte[] value = cacheSerializer(UploadCourseDetailCacheItem.class).serialize(item);
             cacheValueRedisTemplate.execute((RedisCallback<Object>) connection -> {
                 connection.stringCommands().set(key, value,
-                    Expiration.seconds(RedisConfig.COURSE_LIST_ITEM_TTL.getSeconds()),
+                    Expiration.seconds(RedisConfig.COURSE_DETAIL_TTL.getSeconds()),
                     SetOption.upsert());
                 return null;
             });

--- a/src/main/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseServiceImpl.java
+++ b/src/main/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseServiceImpl.java
@@ -26,6 +26,7 @@ import backend.yourtrip.domain.uploadcourse.entity.CourseKeyword;
 import backend.yourtrip.domain.uploadcourse.entity.UploadCourse;
 import backend.yourtrip.domain.uploadcourse.entity.enums.KeywordType;
 import backend.yourtrip.domain.uploadcourse.entity.enums.UploadCourseSortType;
+import backend.yourtrip.domain.uploadcourse.event.UploadCourseCacheRefreshEvent;
 import backend.yourtrip.domain.uploadcourse.mapper.UploadCourseMapper;
 import backend.yourtrip.domain.uploadcourse.repository.UploadCourseRepository;
 import backend.yourtrip.domain.user.entity.User;
@@ -54,6 +55,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -63,6 +65,8 @@ import org.springframework.data.redis.connection.RedisStringCommands.SetOption;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
@@ -108,6 +112,7 @@ public class UploadCourseServiceImpl implements UploadCourseService {
     private final RedisTemplate<String, Object> cacheValueRedisTemplate;
     private final ObjectMapper objectMapper;
     private final UploadCourseViewCountService uploadCourseViewCountService;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * GenericJackson2JsonRedisSerializer(RedisConfig.cacheValueSerializer())는 값에 타입 정보(@class)를
@@ -548,6 +553,28 @@ public class UploadCourseServiceImpl implements UploadCourseService {
         return (COURSE_DETAIL_CACHE + "::" + uploadCourseId).getBytes(StandardCharsets.UTF_8);
     }
 
+    // ==========================
+    //  4단계: 수정 API 캐시 write-through (updateUploadCourse 전용)
+    // ==========================
+
+    /**
+     * updateUploadCourse 트랜잭션이 커밋에 성공한 뒤에만 실행된다. 커밋 전에 캐시부터 갱신하면,
+     * 그 뒤 커밋이 실패(제약 위반 등)했을 때 "DB엔 반영 안 됐는데 캐시엔 새 값이 들어간" 상태가
+     * 남을 수 있어 AFTER_COMMIT으로 묶었다. 이벤트가 이미 write-through에 필요한 캐시 DTO를
+     * 전부 담고 있으므로, 여기서는 엔티티/영속성 컨텍스트에 다시 접근하지 않고 캐시 쓰기만 한다.
+     * writeDetailCache/writeItemCache 자체가 fail-open(예외를 삼키고 WARN 로그)이라 이 리스너도
+     * 동일한 정책을 그대로 물려받는다.
+     * private이 아닌 이유: 이 클래스는 @Transactional로 AOP 프록시가 씌워지는데, @EventListener 계열
+     * 처리기는 프록시를 통해 대상 빈의 리스너 메서드를 호출한다. private 메서드는 프록시가 대상 빈에
+     * 위임할 수 없어 기동 시점에 BeanInitializationException이 발생한다(실측 확인) — 패키지 프라이빗
+     * 이상의 가시성이 필요하다.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    void refreshUploadCourseCaches(UploadCourseCacheRefreshEvent event) {
+        writeDetailCache(event.uploadCourseId(), event.detailCacheItem());
+        writeItemCache(event.uploadCourseId(), event.listItemCacheItem());
+    }
+
     private String getThumbnailUrlFromDetailCache(UploadCourseDetailCacheItem item) {
         if (item.thumbnailImageS3Key() == null) {
             return null;
@@ -770,6 +797,16 @@ public class UploadCourseServiceImpl implements UploadCourseService {
         }
 
         List<DayScheduleResponse> updatedDaySchedules = myCourseService.getAllDaySchedulesByCourse(travelCourse.getId());
+
+        // 5. 캐시 write-through 이벤트 발행 (커밋 성공 후에만 실제 캐시 쓰기가 실행됨, 6-2단계 아래 리스너 참고)
+        // 영속성 컨텍스트가 아직 살아있는 이 시점에 캐시 DTO를 미리 조립해 이벤트에 담는다. 커밋 이후
+        // 리스너에서 엔티티에 다시 접근하면 세션이 닫혀 LazyInitializationException이 날 수 있기 때문이다.
+        UploadCourseDetailCacheItem detailCacheItem = UploadCourseMapper.toDetailCacheItem(uploadCourse,
+            travelCourse.getDaySchedules());
+        CourseListItemCacheItem listItemCacheItem = UploadCourseMapper.toCourseListItemCacheItem(uploadCourse);
+        eventPublisher.publishEvent(
+            new UploadCourseCacheRefreshEvent(uploadCourseId, detailCacheItem, listItemCacheItem));
+
         return UploadCourseMapper.toDetailResponse(uploadCourse, getGetThumbnailUrl(uploadCourse), updatedDaySchedules);
     }
 

--- a/src/main/java/backend/yourtrip/global/config/RedisConfig.java
+++ b/src/main/java/backend/yourtrip/global/config/RedisConfig.java
@@ -30,8 +30,13 @@ public class RedisConfig implements CachingConfigurer {
 
     // 인기 목록 안전망 TTL — 조회수 동기화 스케줄러(10분 주기)가 멈췄을 때를 대비한 마지노선.
     private static final Duration POPULAR_COURSES_TTL = Duration.ofMinutes(30);
-    // 상세 캐시 기본 TTL — 실제 적용 시점에는 동시 만료를 피하기 위해 ± jitter가 더해진다.
-    private static final Duration COURSE_DETAIL_TTL = Duration.ofMinutes(5);
+    // 상세 캐시 TTL — 원래 5분이었으나 실제 값과 어긋나 있었다(코드는 COURSE_LIST_ITEM_TTL을 그대로
+    // 재사용 중이었음). 상세 캐시가 담는 필드의 변경 빈도가 아이템 캐시와 다를 게 없어 값을 2시간으로
+    // 맞추고, updateUploadCourse의 write-through 리스너(refreshUploadCourseCaches)가 이 상수를 직접
+    // 참조하도록 정리했다. 콘텐츠가 실제로 바뀌는 시점의 정합성은 이 TTL이 아니라 그 write-through로
+    // 보장한다 — TTL은 Redis 장애/재시작으로 write-through가 누락됐을 때의 안전망 역할만 한다.
+    // public: UploadCourseServiceImpl의 writeDetailCache에서도 참조해야 해서 공유한다.
+    public static final Duration COURSE_DETAIL_TTL = Duration.ofHours(2);
     // 코스 콘텐츠(엔티티 ID 단위) 캐시 TTL — 거의 안 바뀌는 read-heavy 데이터라 넉넉하게 잡는다.
     // 정합성은 이 TTL이 아니라 콘텐츠 변경 이벤트 발생 시의 write-through(cache.put)로 보장한다.
     // public: 아이템 캐시를 파이프라인으로 직접 쓰는 UploadCourseServiceImpl에서도 동일 TTL을 적용해야 해서 공유한다.

--- a/src/test/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseServiceImplTest.java
+++ b/src/test/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseServiceImplTest.java
@@ -18,6 +18,7 @@ import backend.yourtrip.domain.uploadcourse.dto.request.UploadCourseUpdateReques
 import backend.yourtrip.domain.uploadcourse.dto.response.UploadCourseDetailResponse;
 import backend.yourtrip.domain.uploadcourse.entity.UploadCourse;
 import backend.yourtrip.domain.uploadcourse.entity.enums.KeywordType;
+import backend.yourtrip.domain.uploadcourse.event.UploadCourseCacheRefreshEvent;
 import backend.yourtrip.domain.uploadcourse.repository.UploadCourseRepository;
 import backend.yourtrip.domain.user.entity.User;
 import backend.yourtrip.domain.user.service.UserService;
@@ -37,6 +38,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.cache.CacheManager;
+import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 class UploadCourseServiceImplTest {
@@ -58,6 +60,9 @@ class UploadCourseServiceImplTest {
 
     @Mock
     private CacheManager cacheManager;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
     private UploadCourseServiceImpl uploadCourseService;
@@ -206,6 +211,7 @@ class UploadCourseServiceImplTest {
         assertThat(uploadCourse.getKeywords()).hasSize(2);
         assertThat(travelCourse.getTitle()).isEqualTo("수정된 경주 여행");
         assertThat(place.getPlaceName()).isEqualTo("수정된 황리단길");
+        verify(eventPublisher).publishEvent(any(UploadCourseCacheRefreshEvent.class));
     }
 
     private void setEntityId(Object entity, Long id) {


### PR DESCRIPTION
## ✅ 작업 내용

### 업로드 코스 수정 API 캐시 write-through
- 업로드 코스를 수정하면 `courseDetail`/`courseListItem` 캐시가 즉시 최신 값으로 갱신된다. 기존에는 DB만 갱신되고 캐시는 그대로 남아, 수정 직후에도 최대 2시간(TTL) 동안 옛 제목/소개/일정 등이 노출됐다.
- 수정 트랜잭션이 커밋에 성공한 뒤에만 캐시가 갱신되도록(`@TransactionalEventListener(AFTER_COMMIT)`) 묶어, 커밋이 실패(롤백)해도 캐시가 DB보다 앞서가는 상태가 생기지 않는다.
- `popularCourses` 랭킹 캐시는 `view_count` 기반이라 이 API가 바꾸는 필드와 무관해 그대로 둔다.

### RedisConfig 죽은 TTL 설정 정리
- `COURSE_DETAIL_TTL`이 5분으로 정의돼 있었지만 실제로는 `writeDetailCache`가 이 상수를 쓰지 않고 `COURSE_LIST_ITEM_TTL`(2시간)을 재사용해와 설정값과 실제 동작이 어긋나 있던 것을 바로잡았다.
- `COURSE_DETAIL_TTL` 값을 실제 사용값인 2시간으로 맞추고, `writeDetailCache`가 이 상수를 직접 참조하도록 변경했다.

## 📌 관련 이슈
closes #66

## 📚 추가 리팩토링 가능성
- `writeItemCache`가 이번 PR 전까지 코드베이스 전체에서 호출부 없는 dead code였다. fork 시 `forkCount` 갱신(`docs/CACHING-ROADMAP.md` 6-2 항목)에도 아직 연결돼 있지 않아, 별도 작업으로 다룰 만하다.
