### PR TITLE
feat: 업로드 코스 조회수 SETNX+TTL 중복 방지 적용

### DIFF
--- a/src/main/java/backend/yourtrip/domain/uploadcourse/controller/UploadCourseController.java
+++ b/src/main/java/backend/yourtrip/domain/uploadcourse/controller/UploadCourseController.java
@@ -9,7 +9,9 @@ import backend.yourtrip.domain.uploadcourse.dto.response.UploadCourseListRespons
 import backend.yourtrip.domain.uploadcourse.entity.enums.KeywordType;
 import backend.yourtrip.domain.uploadcourse.entity.enums.UploadCourseSortType;
 import backend.yourtrip.domain.uploadcourse.service.UploadCourseService;
+import backend.yourtrip.global.common.ClientRequestUtils;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -62,8 +64,10 @@ public class UploadCourseController implements UploadCourseControllerSpec {
     @Override
     @GetMapping("/{uploadCourseId}")
     public UploadCourseDetailResponse getUploadCourseDetail(
-        @PathVariable Long uploadCourseId) {
-        return uploadCourseService.getDetail(uploadCourseId);
+        @PathVariable Long uploadCourseId, HttpServletRequest request) {
+        String viewerKey = uploadCourseService.resolveViewerKey(
+            ClientRequestUtils.resolveClientIp(request), request.getHeader("User-Agent"));
+        return uploadCourseService.getDetail(uploadCourseId, viewerKey);
     }
 
     // ==========================

--- a/src/main/java/backend/yourtrip/domain/uploadcourse/controller/UploadCourseControllerSpec.java
+++ b/src/main/java/backend/yourtrip/domain/uploadcourse/controller/UploadCourseControllerSpec.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -266,7 +267,8 @@ public interface UploadCourseControllerSpec {
             )
         )
     })
-    UploadCourseDetailResponse getUploadCourseDetail(@Schema(example = "1") Long uploadCourseId);
+    UploadCourseDetailResponse getUploadCourseDetail(@Schema(example = "1") Long uploadCourseId,
+        @Parameter(hidden = true) HttpServletRequest request);
 
     // ==========================
     //  코스 업로드

--- a/src/main/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseService.java
+++ b/src/main/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseService.java
@@ -19,7 +19,13 @@ public interface UploadCourseService {
     UploadCourseCreateResponse createUploadCourse(UploadCourseCreateRequest request,
         MultipartFile thumbnailImage);
 
-    UploadCourseDetailResponse getDetail(Long uploadCourseId);
+    UploadCourseDetailResponse getDetail(Long uploadCourseId, String viewerKey);
+
+    /**
+     * 컨트롤러에서 추출한 클라이언트 IP/User-Agent로, 조회수 중복 방지에 쓸 viewerKey를 만든다.
+     * 로그인 여부 판별까지 이 메서드 내부에서 처리해, 컨트롤러가 UserService에 직접 의존하지 않게 한다.
+     */
+    String resolveViewerKey(String clientIp, String userAgent);
 
     UploadCourseListResponse getAllForSearch(String keyword, List<KeywordType> tags,
         UploadCourseSortType sortType);

--- a/src/main/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseServiceImpl.java
+++ b/src/main/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseServiceImpl.java
@@ -168,9 +168,15 @@ public class UploadCourseServiceImpl implements UploadCourseService {
     }
 
     @Override
+    public String resolveViewerKey(String clientIp, String userAgent) {
+        Long userId = userService.getCurrentUserIdOrNull();
+        return uploadCourseViewCountService.resolveViewerKey(userId, clientIp, userAgent);
+    }
+
+    @Override
     @Transactional(readOnly = true)
-    public UploadCourseDetailResponse getDetail(Long uploadCourseId) {
-        uploadCourseViewCountService.incrementViewCount(uploadCourseId);
+    public UploadCourseDetailResponse getDetail(Long uploadCourseId, String viewerKey) {
+        uploadCourseViewCountService.incrementViewCountIfNotDuplicate(uploadCourseId, viewerKey);
 
         UploadCourseDetailCacheItem cached = readDetailCache(uploadCourseId);
         if (cached != null) {

--- a/src/main/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseViewCountService.java
+++ b/src/main/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseViewCountService.java
@@ -7,6 +7,10 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.HexFormat;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -18,8 +22,40 @@ public class UploadCourseViewCountService {
 
     public static final String VIEW_COUNT_INCREMENT_KEY_PREFIX = "view_count:increment:";
     public static final String VIEW_COUNT_DIRTY_SET_KEY = "view_count_dirty";
+    public static final String VIEW_DEDUP_KEY_PREFIX = "view_dedup:";
+
+    private static final String LOGGED_IN_VIEWER_PREFIX = "u";
+    private static final String ANONYMOUS_VIEWER_PREFIX = "a";
+    private static final String UNKNOWN_PLACEHOLDER = "unknown";
+    private static final String VIEW_DEDUP_MARKER = "1";
+    private static final Duration VIEW_DEDUP_TTL = Duration.ofHours(24);
 
     private final RedisTemplate<String, String> redisTemplate;
+
+    /**
+     * 로그인 사용자는 userId, 비로그인 사용자는 IP+User-Agent 해시로 조회자를 식별한다.
+     * 접두사(u/a)로 네임스페이스를 분리해, 우연히 같은 문자열이 되어도 로그인·비로그인 조회자가
+     * 서로 다른 dedup 키를 갖도록 보장한다.
+     */
+    public String resolveViewerKey(Long userId, String clientIp, String userAgent) {
+        if (userId != null) {
+            return LOGGED_IN_VIEWER_PREFIX + userId;
+        }
+        return ANONYMOUS_VIEWER_PREFIX + hashAnonymousViewer(clientIp, userAgent);
+    }
+
+    private String hashAnonymousViewer(String clientIp, String userAgent) {
+        String raw = (clientIp == null || clientIp.isBlank() ? UNKNOWN_PLACEHOLDER : clientIp)
+            + "|" + (userAgent == null || userAgent.isBlank() ? UNKNOWN_PLACEHOLDER : userAgent);
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(raw.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            // JDK 표준 알고리즘이라 실질적으로 발생하지 않는다.
+            throw new IllegalStateException("SHA-256 알고리즘을 사용할 수 없습니다.", e);
+        }
+    }
 
     public void incrementViewCount(Long uploadCourseId) {
         try {
@@ -29,6 +65,31 @@ public class UploadCourseViewCountService {
         } catch (Exception e) {
             // Redis 장애 격리 (fail-open)
             log.warn("Redis 조회수 카운터 증가 실패. uploadCourseId={}", uploadCourseId, e);
+        }
+    }
+
+    /**
+     * 같은 조회자(viewerKey)가 TTL(24시간) 내에 이미 조회했다면 조회수를 증가시키지 않는다.
+     * dedup 체크 자체가 Redis 장애로 실패한 경우에는 fail-open으로 간주해 증가시킨다 —
+     * incrementViewCount()의 fail-open 정책과 일관성을 맞춘 것이다.
+     */
+    public void incrementViewCountIfNotDuplicate(Long uploadCourseId, String viewerKey) {
+        if (tryMarkViewed(uploadCourseId, viewerKey)) {
+            incrementViewCount(uploadCourseId);
+        }
+    }
+
+    private boolean tryMarkViewed(Long uploadCourseId, String viewerKey) {
+        try {
+            String dedupKey = VIEW_DEDUP_KEY_PREFIX + uploadCourseId + ":" + viewerKey;
+            Boolean isFirstView = redisTemplate.opsForValue()
+                .setIfAbsent(dedupKey, VIEW_DEDUP_MARKER, VIEW_DEDUP_TTL);
+            return Boolean.TRUE.equals(isFirstView);
+        } catch (Exception e) {
+            // Redis 장애 격리 (fail-open) — dedup 체크가 실패해도 조회수 자체는 정상 반영되어야 한다.
+            log.warn("Redis 조회수 중복 방지 체크 실패. uploadCourseId={}, viewerKey={}", uploadCourseId,
+                viewerKey, e);
+            return true;
         }
     }
 

--- a/src/main/java/backend/yourtrip/domain/user/service/UserService.java
+++ b/src/main/java/backend/yourtrip/domain/user/service/UserService.java
@@ -30,4 +30,10 @@ public interface UserService {
     User getUser(Long userId);
 
     Long getCurrentUserId();
+
+    /**
+     * getCurrentUserId()와 달리 비로그인 상태에서도 예외를 던지지 않고 null을 반환한다.
+     * 로그인 여부에 따라 분기해야 하는 곳(예: 비로그인도 허용된 API)에서 사용한다.
+     */
+    Long getCurrentUserIdOrNull();
 }

--- a/src/main/java/backend/yourtrip/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/backend/yourtrip/domain/user/service/UserServiceImpl.java
@@ -218,6 +218,19 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    public Long getCurrentUserIdOrNull() {
+        Object principal = SecurityContextHolder.getContext()
+            .getAuthentication() != null
+            ? SecurityContextHolder.getContext().getAuthentication().getPrincipal()
+            : null;
+
+        if (principal instanceof CustomUserDetails userDetails) {
+            return userDetails.getUserId();
+        }
+        return null;
+    }
+
+    @Override
     public void findPasswordSendEmail(String email) {
         userRepository.findByEmail(email)
             .orElseThrow(() -> new BusinessException(UserErrorCode.EMAIL_NOT_FOUND));

--- a/src/main/java/backend/yourtrip/global/common/ClientRequestUtils.java
+++ b/src/main/java/backend/yourtrip/global/common/ClientRequestUtils.java
@@ -1,0 +1,23 @@
+package backend.yourtrip.global.common;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public final class ClientRequestUtils {
+
+    private static final String FORWARDED_FOR_HEADER = "X-Forwarded-For";
+
+    private ClientRequestUtils() {
+    }
+
+    /**
+     * 리버스 프록시(로드밸런서 등)를 거치면 소켓 연결 정보(getRemoteAddr)가 프록시 주소로 잡히므로,
+     * X-Forwarded-For 헤더가 있으면 그 첫 번째 값(최초 클라이언트 IP)을 우선 사용하고 없을 때만 폴백한다.
+     */
+    public static String resolveClientIp(HttpServletRequest request) {
+        String forwardedFor = request.getHeader(FORWARDED_FOR_HEADER);
+        if (forwardedFor != null && !forwardedFor.isBlank()) {
+            return forwardedFor.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+}

--- a/src/test/java/backend/yourtrip/domain/uploadcourse/controller/UploadCourseControllerE2ETest.java
+++ b/src/test/java/backend/yourtrip/domain/uploadcourse/controller/UploadCourseControllerE2ETest.java
@@ -1,9 +1,11 @@
 package backend.yourtrip.domain.uploadcourse.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -52,6 +54,38 @@ class UploadCourseControllerE2ETest {
 
     @MockBean
     private UserRepository userRepository;
+
+    @Test
+    @DisplayName("GET /api/upload-courses/{uploadCourseId} - 요청의 IP/User-Agent로 계산한 viewerKey를 getDetail에 전달하고 200 OK를 반환한다")
+    void getUploadCourseDetail_Success() throws Exception {
+        // given
+        Long uploadCourseId = 1L;
+        String viewerKey = "a1b2c3";
+
+        UploadCourseDetailResponse expectedResponse = UploadCourseDetailResponse.builder()
+            .uploadCourseId(uploadCourseId)
+            .title("경주 인생샷 코스")
+            .introduction("황리단길과 첨성대 야경")
+            .location("경주")
+            .thumbnailImageUrl("http://s3.com/thumbnail.png")
+            .startDate(LocalDate.of(2025, 3, 1))
+            .endDate(LocalDate.of(2025, 3, 1))
+            .forkCount(5)
+            .keywords(List.of("뚜벅이", "맛집탐방"))
+            .daySchedules(List.of())
+            .build();
+
+        given(uploadCourseService.resolveViewerKey(anyString(), anyString())).willReturn(viewerKey);
+        given(uploadCourseService.getDetail(uploadCourseId, viewerKey)).willReturn(expectedResponse);
+
+        // when & then
+        mockMvc.perform(get("/api/upload-courses/{uploadCourseId}", uploadCourseId)
+                .header("User-Agent", "Mozilla/5.0"))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.uploadCourseId").value(uploadCourseId))
+            .andExpect(jsonPath("$.title").value("경주 인생샷 코스"));
+    }
 
     @Test
     @DisplayName("PUT /api/upload-courses/{uploadCourseId} - 로그인한 사용자가 정상적인 정보로 수정 시 200 OK와 수정된 코스 상세 응답을 반환한다")

--- a/src/test/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseServiceImplTest.java
+++ b/src/test/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseServiceImplTest.java
@@ -26,6 +26,7 @@ import backend.yourtrip.global.exception.BusinessException;
 import backend.yourtrip.global.exception.errorCode.UploadCourseErrorCode;
 import backend.yourtrip.global.cloudfront.service.CloudFrontService;
 import backend.yourtrip.global.s3.service.S3Service;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
@@ -39,6 +40,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.cache.CacheManager;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.redis.core.RedisTemplate;
 
 @ExtendWith(MockitoExtension.class)
 class UploadCourseServiceImplTest {
@@ -63,6 +65,15 @@ class UploadCourseServiceImplTest {
 
     @Mock
     private ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    private UploadCourseViewCountService uploadCourseViewCountService;
+
+    @Mock
+    private RedisTemplate<String, Object> cacheValueRedisTemplate;
+
+    @Mock
+    private ObjectMapper objectMapper;
 
     @InjectMocks
     private UploadCourseServiceImpl uploadCourseService;
@@ -212,6 +223,61 @@ class UploadCourseServiceImplTest {
         assertThat(travelCourse.getTitle()).isEqualTo("수정된 경주 여행");
         assertThat(place.getPlaceName()).isEqualTo("수정된 황리단길");
         verify(eventPublisher).publishEvent(any(UploadCourseCacheRefreshEvent.class));
+    }
+
+    @Test
+    @DisplayName("resolveViewerKey는 로그인 여부를 판별해 viewerKey 계산을 위임한다")
+    void resolveViewerKey_DelegatesToViewCountService() {
+        // given
+        given(userService.getCurrentUserIdOrNull()).willReturn(5L);
+        given(uploadCourseViewCountService.resolveViewerKey(5L, "1.2.3.4", "Mozilla/5.0"))
+            .willReturn("u5");
+
+        // when
+        String viewerKey = uploadCourseService.resolveViewerKey("1.2.3.4", "Mozilla/5.0");
+
+        // then
+        assertThat(viewerKey).isEqualTo("u5");
+        verify(uploadCourseViewCountService).resolveViewerKey(5L, "1.2.3.4", "Mozilla/5.0");
+    }
+
+    @Test
+    @DisplayName("getDetail 호출 시 전달받은 viewerKey로 조회수 중복 방지 게이트를 호출한다")
+    void getDetail_CallsViewCountGateWithViewerKey() {
+        // given
+        Long uploadCourseId = 1L;
+        String viewerKey = "u5";
+
+        User owner = User.builder().email("owner@test.com").password("pass").nickname("owner").build();
+        setEntityId(owner, 10L);
+
+        TravelCourse travelCourse = TravelCourse.builder()
+            .user(owner)
+            .title("경주 여행")
+            .location("경주")
+            .startDate(LocalDate.now())
+            .endDate(LocalDate.now())
+            .type(TravelCourseType.UPLOADED)
+            .build();
+        setEntityId(travelCourse, 100L);
+
+        UploadCourse uploadCourse = UploadCourse.builder()
+            .title("경주 여행")
+            .introduction("소개")
+            .travelCourse(travelCourse)
+            .user(owner)
+            .location("경주")
+            .build();
+
+        given(uploadCourseRepository.findWithTravelCourseAndKeywords(uploadCourseId))
+            .willReturn(Optional.of(uploadCourse));
+        given(myCourseService.getDaySchedulesWithPlaces(100L)).willReturn(List.of());
+
+        // when
+        uploadCourseService.getDetail(uploadCourseId, viewerKey);
+
+        // then
+        verify(uploadCourseViewCountService).incrementViewCountIfNotDuplicate(uploadCourseId, viewerKey);
     }
 
     private void setEntityId(Object entity, Long id) {

--- a/src/test/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseViewCountServiceTest.java
+++ b/src/test/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseViewCountServiceTest.java
@@ -1,0 +1,131 @@
+package backend.yourtrip.domain.uploadcourse.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.time.Duration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SetOperations;
+import org.springframework.data.redis.core.ValueOperations;
+
+@ExtendWith(MockitoExtension.class)
+class UploadCourseViewCountServiceTest {
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @Mock
+    private SetOperations<String, String> setOperations;
+
+    @InjectMocks
+    private UploadCourseViewCountService uploadCourseViewCountService;
+
+    @Test
+    @DisplayName("로그인 사용자는 userId 기반 viewerKey를 반환한다")
+    void resolveViewerKey_LoggedInUser_ReturnsUserPrefixedKey() {
+        String viewerKey = uploadCourseViewCountService.resolveViewerKey(42L, "1.2.3.4", "Mozilla/5.0");
+
+        assertThat(viewerKey).isEqualTo("u42");
+    }
+
+    @Test
+    @DisplayName("비로그인 사용자는 IP+User-Agent 해시 기반 viewerKey를 반환한다")
+    void resolveViewerKey_AnonymousUser_ReturnsHashedKey() {
+        String viewerKey = uploadCourseViewCountService.resolveViewerKey(null, "1.2.3.4", "Mozilla/5.0");
+
+        assertThat(viewerKey).startsWith("a");
+        assertThat(viewerKey).hasSize(1 + 64); // "a" + SHA-256 hex(64자)
+    }
+
+    @Test
+    @DisplayName("동일한 IP+User-Agent는 항상 같은 viewerKey를 만든다")
+    void resolveViewerKey_SameIpAndUserAgent_ReturnsSameHash() {
+        String first = uploadCourseViewCountService.resolveViewerKey(null, "1.2.3.4", "Mozilla/5.0");
+        String second = uploadCourseViewCountService.resolveViewerKey(null, "1.2.3.4", "Mozilla/5.0");
+
+        assertThat(first).isEqualTo(second);
+    }
+
+    @Test
+    @DisplayName("IP나 User-Agent가 다르면 다른 viewerKey를 만든다")
+    void resolveViewerKey_DifferentIpOrUserAgent_ReturnsDifferentHash() {
+        String first = uploadCourseViewCountService.resolveViewerKey(null, "1.2.3.4", "Mozilla/5.0");
+        String second = uploadCourseViewCountService.resolveViewerKey(null, "5.6.7.8", "Mozilla/5.0");
+
+        assertThat(first).isNotEqualTo(second);
+    }
+
+    @Test
+    @DisplayName("User-Agent가 없어도(null) 예외 없이 처리한다")
+    void resolveViewerKey_NullUserAgent_DoesNotThrow() {
+        String viewerKey = uploadCourseViewCountService.resolveViewerKey(null, "1.2.3.4", null);
+
+        assertThat(viewerKey).startsWith("a");
+    }
+
+    @Test
+    @DisplayName("로그인 사용자와 비로그인 사용자의 viewerKey는 접두사로 구분되어 충돌하지 않는다")
+    void resolveViewerKey_LoggedInAndAnonymous_NeverCollide() {
+        String loggedIn = uploadCourseViewCountService.resolveViewerKey(1L, "1.2.3.4", "Mozilla/5.0");
+        String anonymous = uploadCourseViewCountService.resolveViewerKey(null, "1.2.3.4", "Mozilla/5.0");
+
+        assertThat(loggedIn).isNotEqualTo(anonymous);
+        assertThat(loggedIn).startsWith("u");
+        assertThat(anonymous).startsWith("a");
+    }
+
+    @Test
+    @DisplayName("TTL 내 최초 방문이면 조회수를 증가시킨다")
+    void incrementViewCountIfNotDuplicate_FirstView_Increments() {
+        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        lenient().when(redisTemplate.opsForSet()).thenReturn(setOperations);
+        given(valueOperations.setIfAbsent(anyString(), eq("1"), eq(Duration.ofHours(24))))
+            .willReturn(true);
+
+        uploadCourseViewCountService.incrementViewCountIfNotDuplicate(1L, "u42");
+
+        verify(valueOperations).increment("view_count:increment:1");
+        verify(setOperations).add("view_count_dirty", "1");
+    }
+
+    @Test
+    @DisplayName("TTL 내 이미 조회한 viewerKey면 조회수를 증가시키지 않는다")
+    void incrementViewCountIfNotDuplicate_DuplicateView_DoesNotIncrement() {
+        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        given(valueOperations.setIfAbsent(anyString(), eq("1"), eq(Duration.ofHours(24))))
+            .willReturn(false);
+
+        uploadCourseViewCountService.incrementViewCountIfNotDuplicate(1L, "u42");
+
+        verify(valueOperations, never()).increment(anyString());
+    }
+
+    @Test
+    @DisplayName("dedup 체크 중 Redis 예외가 발생하면 fail-open으로 조회수를 증가시킨다")
+    void incrementViewCountIfNotDuplicate_RedisException_FailsOpenAndIncrements() {
+        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        lenient().when(redisTemplate.opsForSet()).thenReturn(setOperations);
+        willThrow(new RuntimeException("Redis 연결 실패"))
+            .given(valueOperations).setIfAbsent(anyString(), eq("1"), eq(Duration.ofHours(24)));
+
+        uploadCourseViewCountService.incrementViewCountIfNotDuplicate(1L, "u42");
+
+        verify(valueOperations).increment("view_count:increment:1");
+        verify(setOperations).add("view_count_dirty", "1");
+    }
+}

--- a/src/test/java/backend/yourtrip/global/common/ClientRequestUtilsTest.java
+++ b/src/test/java/backend/yourtrip/global/common/ClientRequestUtilsTest.java
@@ -1,0 +1,47 @@
+package backend.yourtrip.global.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ClientRequestUtilsTest {
+
+    @Test
+    @DisplayName("X-Forwarded-For 헤더가 있으면 첫 번째 IP를 사용한다")
+    void resolveClientIp_WithForwardedForHeader_ReturnsFirstIp() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        given(request.getHeader("X-Forwarded-For")).willReturn("203.0.113.1, 10.0.0.1, 10.0.0.2");
+
+        String clientIp = ClientRequestUtils.resolveClientIp(request);
+
+        assertThat(clientIp).isEqualTo("203.0.113.1");
+    }
+
+    @Test
+    @DisplayName("X-Forwarded-For 헤더가 없으면 getRemoteAddr로 폴백한다")
+    void resolveClientIp_WithoutForwardedForHeader_FallsBackToRemoteAddr() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        given(request.getHeader("X-Forwarded-For")).willReturn(null);
+        given(request.getRemoteAddr()).willReturn("192.168.0.10");
+
+        String clientIp = ClientRequestUtils.resolveClientIp(request);
+
+        assertThat(clientIp).isEqualTo("192.168.0.10");
+    }
+
+    @Test
+    @DisplayName("X-Forwarded-For 헤더가 빈 문자열이면 getRemoteAddr로 폴백한다")
+    void resolveClientIp_WithBlankForwardedForHeader_FallsBackToRemoteAddr() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        given(request.getHeader("X-Forwarded-For")).willReturn("  ");
+        given(request.getRemoteAddr()).willReturn("192.168.0.10");
+
+        String clientIp = ClientRequestUtils.resolveClientIp(request);
+
+        assertThat(clientIp).isEqualTo("192.168.0.10");
+    }
+}


### PR DESCRIPTION
## ✅ 작업 내용

### 조회수 중복 집계 방지
- 업로드 코스 상세 조회 시 새로고침이나 봇 요청에도 조회수가 무한정 증가하던 문제를, 조회자당 24시간 내 1회만 조회수를 올리도록 개선했다
- 로그인 사용자는 userId, 비로그인 사용자는 클라이언트 IP + User-Agent 해시로 조회자를 식별한다(업로드 코스 상세는 비로그인도 조회 가능)
- Redis `SET NX EX`(SETNX+TTL)로 원자적으로 조회 여부를 선점해, 동시 요청에도 중복 집계 없이 정확하게 최초 조회만 판별한다
- dedup 체크 자체가 Redis 장애로 실패해도 fail-open으로 조회수는 정상 반영되어, 기존 조회수 카운터의 fail-open 정책과 일관성을 유지한다

### 기존 조회수 파이프라인은 변경 없음
- Redis INCR 기반 카운터, dirty set, 10분 주기 DB 동기화 스케줄러는 전혀 건드리지 않았다
- dedup은 기존 카운터 증가 호출 앞단에 게이트 하나만 추가하는 방식으로 통합했다

## 📌 관련 이슈
관련 이슈 없음(대화를 통해 조사·설계 후 진행한 개선 작업)

## 📚 추가 리팩토링 가능성

- **비로그인 조회자 dedup 정확도**: 현재는 IP+User-Agent 해시 방식이라, NAT/사내망처럼 IP를 공유하는 환경에서는 서로 다른 사람이 같은 조회자로 묶일 수 있다. 정확도가 더 중요해지면 서버 발급 익명 쿠키 방식으로 전환할 수 있다.
- **로그인 사용자 경로의 브라우저 E2E 검증 공백**: 이번 PR에서 비로그인 경로는 Playwright로 실제 브라우저 요청까지 검증했지만, 로그인 사용자 경로는 시드 데이터에 테스트 계정 평문 비밀번호가 없어 단위테스트로만 검증했다. 회귀 테스트용 테스트 계정을 시드에 마련하면 로그인 경로도 브라우저 E2E로 커버할 수 있다.
- **조회수 DB 반영 스케줄러의 DB 커넥션 풀 분리**: 현재 스케줄러는 웹 요청과 동일한 HikariCP 풀을 공유한다. 지금 규모(순차 처리, 짧은 인덱스 기반 쿼리)에서는 문제되지 않지만, 향후 처리를 병렬화하거나 트래픽이 커지면 배치 전용 커넥션 풀 분리를 검토할 수 있다.