### PR TITLE
feat: 나의 코스 / 업로드 코스 삭제 API 및 Redis 캐시 즉시 무효화 추가

### DIFF
--- a/src/main/java/backend/yourtrip/domain/mycourse/controller/MyCourseController.java
+++ b/src/main/java/backend/yourtrip/domain/mycourse/controller/MyCourseController.java
@@ -71,6 +71,16 @@ public class MyCourseController implements MyCourseControllerSpec {
     }
 
     // ==========================
+    //  나의 코스 삭제
+    // ==========================
+    @Override
+    @DeleteMapping("/{courseId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteMyCourse(@PathVariable Long courseId) {
+        myCourseService.deleteCourse(courseId);
+    }
+
+    // ==========================
     //  일차별 장소 리스트 조회
     // ==========================
     @Override

--- a/src/main/java/backend/yourtrip/domain/mycourse/controller/MyCourseControllerSpec.java
+++ b/src/main/java/backend/yourtrip/domain/mycourse/controller/MyCourseControllerSpec.java
@@ -254,6 +254,60 @@ public interface MyCourseControllerSpec {
     MyCourseDetailResponse getMyCourse(@Schema(example = "1") Long courseId);
 
     // ==========================
+    //  나의 코스 삭제
+    // ==========================
+    @Operation(summary = "나의 코스 삭제", description = """
+        ### 설명
+        - 특정 코스를 삭제합니다. 코스에 속한 모든 일차/장소/장소이미지가 함께 삭제됩니다(S3에 업로드된 장소 이미지 파일도 함께 정리됩니다).
+        - 이미 업로드된 코스(업로드 코스 목록에 노출 중인 코스)여도 원본 삭제가 차단되지 않습니다. 원본과 업로드 코스는 업로드 시점에 복제되어 서로 독립된 데이터이므로, 원본을 삭제해도 이미 업로드된 코스는 그대로 유지됩니다.
+        ### 제약조건
+        - 경로 변수
+            - 코스 ID(courseId): 존재하는 코스여야 함
+        ### ⚠ 예외상황
+        - `COURSE_NOT_FOUND(404)`: 코스가 존재하지 않는 경우 (잘못된 courseId가 주어진 경우)
+        - `NOT_OWNED_COURSE(403)`: 본인 소유가 아닌 코스에 접근한 경우
+        """)
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "204",
+            description = "나의 코스 삭제 성공"
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "잘못된 courseId가 주어졌을 때",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(
+                    value = """
+                        {
+                          "timestamp": "2025-11-10T11:00:00",
+                          "code": "COURSE_NOT_FOUND",
+                          "message": "코스를 찾을 수 없습니다."
+                        }
+                        """
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "403",
+            description = "소유하지 않은 코스에 접근할 때",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(
+                    value = """
+                        {
+                          "timestamp": "2025-11-10T11:00:00",
+                          "code": "NOT_OWNED_COURSE",
+                          "message": "해당 코스에 대한 접근 권한이 없습니다."
+                        }
+                        """
+                )
+            )
+        )
+    })
+    void deleteMyCourse(@Schema(example = "1") Long courseId);
+
+    // ==========================
     //  일차별 장소 리스트 조회
     // ==========================
     @Operation(

--- a/src/main/java/backend/yourtrip/domain/mycourse/event/MyCourseImagesCleanupEvent.java
+++ b/src/main/java/backend/yourtrip/domain/mycourse/event/MyCourseImagesCleanupEvent.java
@@ -1,0 +1,12 @@
+package backend.yourtrip.domain.mycourse.event;
+
+import java.util.List;
+
+/**
+ * 코스 삭제 트랜잭션이 커밋된 뒤 S3에서 정리해야 할 장소 이미지 key 목록을 담아 발행하는 이벤트.
+ * 영속성 컨텍스트가 살아있는 트랜잭션 내부에서 미리 수집한 key만 담아, 커밋 이후 리스너가
+ * 엔티티에 다시 접근하지 않고 S3 삭제만 수행하도록 한다.
+ */
+public record MyCourseImagesCleanupEvent(List<String> imageS3Keys) {
+
+}

--- a/src/main/java/backend/yourtrip/domain/mycourse/service/MyCourseService.java
+++ b/src/main/java/backend/yourtrip/domain/mycourse/service/MyCourseService.java
@@ -48,6 +48,14 @@ public interface MyCourseService {
 
     void deletePlace(Long courseId, Long dayId, Long placeId);
 
+    void deleteCourse(Long courseId);
+
+    /**
+     * uploadCourse 삭제 시 그 뒤에 숨은 사본(TravelCourseType.UPLOADED)을 함께 정리하기 위해
+     * UploadCourseServiceImpl이 호출한다. 원본 mycourse 삭제(deleteCourse)와는 별개의 흐름이다.
+     */
+    void deleteHiddenUploadCopy(TravelCourse hiddenCopy);
+
     MyCourseDetailResponse getMyCourseDetail(Long courseId);
 
     CourseForkResponse forkCourse(Long uploadCourseId);

--- a/src/main/java/backend/yourtrip/domain/mycourse/service/MyCourseServiceImpl.java
+++ b/src/main/java/backend/yourtrip/domain/mycourse/service/MyCourseServiceImpl.java
@@ -22,6 +22,7 @@ import backend.yourtrip.domain.mycourse.entity.place.Place;
 import backend.yourtrip.domain.mycourse.entity.place.PlaceImage;
 import backend.yourtrip.domain.mycourse.entity.travelCourse.TravelCourse;
 import backend.yourtrip.domain.mycourse.entity.travelCourse.enums.TravelCourseType;
+import backend.yourtrip.domain.mycourse.event.MyCourseImagesCleanupEvent;
 import backend.yourtrip.domain.mycourse.mapper.DayScheduleMapper;
 import backend.yourtrip.domain.mycourse.mapper.PlaceMapper;
 import backend.yourtrip.domain.mycourse.mapper.TravelCourseMapper;
@@ -56,9 +57,13 @@ import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
@@ -81,6 +86,7 @@ public class MyCourseServiceImpl implements MyCourseService {
     private final KakaoLocalClient kakaoLocalClient;
     @Qualifier("cloudFrontSigningExecutor")
     private final ThreadPoolTaskExecutor cloudFrontSigningExecutor;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     @Transactional
@@ -342,6 +348,63 @@ public class MyCourseServiceImpl implements MyCourseService {
         place.getPlaceImages().forEach(placeImage ->
             s3Service.deleteFile(placeImage.getPlaceImageS3Key())
         );
+    }
+
+    /**
+     * uploadCourse는 원본 mycourse와 완전히 독립된 데이터로 취급한다(업로드 시점에 딥카피된
+     * 별도 사본이므로). 따라서 원본이 이미 업로드된 상태(uploaded=true)여도 이 삭제를 막지
+     * 않는다 — 원본을 지워도 이미 공개된 uploadCourse는 그대로 유지된다.
+     */
+    @Override
+    @Transactional
+    public void deleteCourse(Long courseId) {
+        checkExistCourse(courseId);
+        Long userId = userService.getCurrentUserId();
+        checkOwnedCourse(courseId, userId);
+
+        TravelCourse travelCourse = travelCourseRepository.findCourseWithDaySchedule(courseId)
+            .orElseThrow(() -> new BusinessException(MyCourseErrorCode.COURSE_NOT_FOUND));
+
+        // day/place/image를 전부 로드해 S3 key를 미리 수집한다(삭제 후에는 엔티티에 접근할 수 없음).
+        // dayScheduleRepository로 조회하지만 같은 트랜잭션(영속성 컨텍스트) 내에서 travelCourse가
+        // 이미 로드해둔 daySchedules와 동일한 관리 엔티티를 공유하므로(1차 캐시), 아래 delete()
+        // 호출 시 cascade가 정상적으로 이 place/image까지 전부 타게 된다.
+        List<DaySchedule> daySchedules = getDaySchedulesWithPlaces(courseId);
+        List<String> imageS3Keys = daySchedules.stream()
+            .flatMap(ds -> ds.getPlaces().stream())
+            .flatMap(place -> place.getPlaceImages().stream())
+            .map(PlaceImage::getPlaceImageS3Key)
+            .toList();
+
+        travelCourseRepository.delete(travelCourse);
+
+        if (!imageS3Keys.isEmpty()) {
+            eventPublisher.publishEvent(new MyCourseImagesCleanupEvent(imageS3Keys));
+        }
+    }
+
+    @Override
+    @Transactional
+    public void deleteHiddenUploadCopy(TravelCourse hiddenCopy) {
+        travelCourseRepository.delete(hiddenCopy);
+    }
+
+    /**
+     * 커밋 확정 후 S3 이미지 정리를 요청 스레드에서 분리해 코스 삭제 API의 응답 시간이 이미지
+     * 개수에 비례해 늘어나지 않도록 한다. 실패한 key는 WARN 로그만 남기고 나머지는 계속
+     * 진행한다(fail-open) — 이 코드베이스 전반의 캐시/외부 I/O 실패 처리 관례와 동일하다.
+     * private이 아닌 이유는 refreshUploadCourseCaches와 동일(AOP 프록시 제약).
+     */
+    @Async("courseImageCleanupExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    void cleanupDeletedCourseImages(MyCourseImagesCleanupEvent event) {
+        for (String key : event.imageS3Keys()) {
+            try {
+                s3Service.deleteFile(key);
+            } catch (Exception e) {
+                log.warn("코스 삭제 후 S3 이미지 정리 실패. key={}", key, e);
+            }
+        }
     }
 
     @Override

--- a/src/main/java/backend/yourtrip/domain/uploadcourse/controller/UploadCourseController.java
+++ b/src/main/java/backend/yourtrip/domain/uploadcourse/controller/UploadCourseController.java
@@ -17,6 +17,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -112,6 +113,16 @@ public class UploadCourseController implements UploadCourseControllerSpec {
         @RequestPart(value = "placeImages", required = false) List<MultipartFile> placeImages,
         @Valid @RequestPart(value = "request") UploadCourseUpdateRequest request) {
         return uploadCourseService.updateUploadCourse(uploadCourseId, request, thumbnailImage, placeImages);
+    }
+
+    // ==========================
+    //  업로드 코스 삭제
+    // ==========================
+    @Override
+    @DeleteMapping("/{uploadCourseId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteUploadCourse(@PathVariable Long uploadCourseId) {
+        uploadCourseService.deleteUploadCourse(uploadCourseId);
     }
 
 }

--- a/src/main/java/backend/yourtrip/domain/uploadcourse/controller/UploadCourseControllerSpec.java
+++ b/src/main/java/backend/yourtrip/domain/uploadcourse/controller/UploadCourseControllerSpec.java
@@ -555,4 +555,62 @@ public interface UploadCourseControllerSpec {
             schema = @Schema(implementation = UploadCourseUpdateRequest.class)
         )) UploadCourseUpdateRequest request);
 
+    // ==========================
+    //  업로드 코스 삭제
+    // ==========================
+    @Operation(
+        summary = "업로드 코스 삭제",
+        description = """
+            ### 설명
+            - 업로드 코스를 삭제합니다. 업로드 시점에 딥카피된 사본(일차/장소/장소이미지 포함)도 함께 삭제됩니다(S3에 업로드된 썸네일/장소 이미지 파일도 함께 정리됩니다).
+            - 원본 "나의 코스"에는 영향을 주지 않습니다 — 업로드 시점에 원본과 분리된 별도 데이터이기 때문입니다.
+            - 삭제 즉시 상세 조회 캐시와 인기 코스 랭킹 캐시가 무효화되어, 삭제 직후 조회/인기 목록에 더 이상 노출되지 않습니다.
+            ### 제약조건
+            - 경로 변수
+                - 업로드 코스 ID(uploadCourseId): 존재하는 업로드 코스여야 함
+            ### ⚠ 예외상황
+            - `UPLOAD_COURSE_NOT_FOUND(404)`: 업로드 코스가 존재하지 않는 경우 (잘못된 uploadCourseId가 주어진 경우)
+            - `NOT_OWNED_UPLOAD_COURSE(403)`: 본인이 업로드한 코스가 아닌 경우
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "204",
+            description = "업로드 코스 삭제 성공"
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "존재하지 않는 uploadCourseId가 주어졌을 때",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(
+                    value = """
+                        {
+                          "code": "UPLOAD_COURSE_NOT_FOUND",
+                          "timestamp": "2025-11-11T00:00:44.7553392",
+                          "message": "업로드 코스를 찾을 수 없습니다."
+                        }
+                        """
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "403",
+            description = "본인이 업로드한 코스가 아닌 경우",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(
+                    value = """
+                        {
+                          "code": "NOT_OWNED_UPLOAD_COURSE",
+                          "timestamp": "2025-11-11T00:00:44.7553392",
+                          "message": "본인이 업로드한 코스만 수정/삭제할 수 있습니다."
+                        }
+                        """
+                )
+            )
+        )
+    })
+    void deleteUploadCourse(@Schema(example = "1") Long uploadCourseId);
+
 }

--- a/src/main/java/backend/yourtrip/domain/uploadcourse/event/UploadCourseDeletedEvent.java
+++ b/src/main/java/backend/yourtrip/domain/uploadcourse/event/UploadCourseDeletedEvent.java
@@ -1,0 +1,10 @@
+package backend.yourtrip.domain.uploadcourse.event;
+
+/**
+ * 업로드 코스 삭제 트랜잭션이 커밋된 뒤 Redis 캐시(상세/아이템/인기 랭킹)를 즉시 무효화하기
+ * 위한 이벤트. 캐시 삭제 자체는 가벼운 명령이라 이 이벤트의 리스너는 동기(AFTER_COMMIT)로
+ * 처리한다 — S3 정리(UploadCourseImagesCleanupEvent, 비동기)와는 관심사를 분리한다.
+ */
+public record UploadCourseDeletedEvent(Long uploadCourseId) {
+
+}

--- a/src/main/java/backend/yourtrip/domain/uploadcourse/event/UploadCourseImagesCleanupEvent.java
+++ b/src/main/java/backend/yourtrip/domain/uploadcourse/event/UploadCourseImagesCleanupEvent.java
@@ -1,0 +1,12 @@
+package backend.yourtrip.domain.uploadcourse.event;
+
+import java.util.List;
+
+/**
+ * 업로드 코스 삭제 트랜잭션이 커밋된 뒤 S3에서 정리해야 할 썸네일/장소 이미지 key 목록을 담아
+ * 발행하는 이벤트. 영속성 컨텍스트가 살아있는 트랜잭션 내부에서 미리 수집한 key만 담아, 커밋
+ * 이후 리스너가 엔티티에 다시 접근하지 않고 S3 삭제만 수행하도록 한다.
+ */
+public record UploadCourseImagesCleanupEvent(List<String> imageS3Keys) {
+
+}

--- a/src/main/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseService.java
+++ b/src/main/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseService.java
@@ -38,6 +38,13 @@ public interface UploadCourseService {
         UploadCourseUpdateRequest request, MultipartFile thumbnailImage,
         List<MultipartFile> placeImages);
 
+    /**
+     * 업로드 코스와 그 뒤에 숨은 사본 mycourse를 함께 삭제한다. 원본 mycourse에는 영향을 주지
+     * 않는다(업로드 시점에 복제된 별도 데이터). 삭제 커밋 후 Redis 상세/아이템/인기 랭킹 캐시를
+     * 즉시 무효화하고, S3 이미지 정리는 비동기로 처리한다.
+     */
+    void deleteUploadCourse(Long uploadCourseId);
+
     void refreshAllPopularCoursesCache();
 
     /**

--- a/src/main/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseServiceImpl.java
+++ b/src/main/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseServiceImpl.java
@@ -27,6 +27,8 @@ import backend.yourtrip.domain.uploadcourse.entity.UploadCourse;
 import backend.yourtrip.domain.uploadcourse.entity.enums.KeywordType;
 import backend.yourtrip.domain.uploadcourse.entity.enums.UploadCourseSortType;
 import backend.yourtrip.domain.uploadcourse.event.UploadCourseCacheRefreshEvent;
+import backend.yourtrip.domain.uploadcourse.event.UploadCourseDeletedEvent;
+import backend.yourtrip.domain.uploadcourse.event.UploadCourseImagesCleanupEvent;
 import backend.yourtrip.domain.uploadcourse.mapper.UploadCourseMapper;
 import backend.yourtrip.domain.uploadcourse.repository.UploadCourseRepository;
 import backend.yourtrip.domain.user.entity.User;
@@ -63,6 +65,7 @@ import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.connection.RedisStringCommands.SetOption;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
@@ -813,6 +816,127 @@ public class UploadCourseServiceImpl implements UploadCourseService {
             new UploadCourseCacheRefreshEvent(uploadCourseId, detailCacheItem, listItemCacheItem));
 
         return UploadCourseMapper.toDetailResponse(uploadCourse, getGetThumbnailUrl(uploadCourse), updatedDaySchedules);
+    }
+
+    // ==========================
+    //  5단계: 삭제 (hidden copy 함께 정리 + Redis 즉시 무효화 + S3 비동기 정리)
+    // ==========================
+
+    /**
+     * 원본 mycourse에는 영향을 주지 않는다 — hidden copy(uploadCourse.travelCourse)는 업로드
+     * 시점에 딥카피된 uploadCourse 자신의 데이터라서 여기서 함께 정리하지만, 원본은 별도 엔티티라
+     * 이 삭제로 건드리지 않는다.
+     */
+    @Override
+    @Transactional
+    public void deleteUploadCourse(Long uploadCourseId) {
+        UploadCourse uploadCourse = uploadCourseRepository.findWithTravelCourseAndKeywords(uploadCourseId)
+            .orElseThrow(() -> new BusinessException(UploadCourseErrorCode.UPLOAD_COURSE_NOT_FOUND));
+
+        Long currentUserId = userService.getCurrentUserId();
+        if (!uploadCourse.getUser().getId().equals(currentUserId)) {
+            throw new BusinessException(UploadCourseErrorCode.NOT_OWNED_UPLOAD_COURSE);
+        }
+
+        TravelCourse hiddenCopy = uploadCourse.getTravelCourse();
+        // hidden copy의 day/place/image를 미리 로드해 S3 key를 수집한다(삭제 후에는 접근 불가).
+        List<DaySchedule> daySchedules = myCourseService.getDaySchedulesWithPlaces(hiddenCopy.getId());
+
+        List<String> imageS3Keys = new ArrayList<>();
+        String thumbnailS3Key = uploadCourse.getThumbnailImageS3Key();
+        if (thumbnailS3Key != null && !"default-upload-course-thumbnail.png".equals(thumbnailS3Key)) {
+            imageS3Keys.add(thumbnailS3Key);
+        }
+        daySchedules.stream()
+            .flatMap(ds -> ds.getPlaces().stream())
+            .flatMap(place -> place.getPlaceImages().stream())
+            .map(PlaceImage::getPlaceImageS3Key)
+            .forEach(imageS3Keys::add);
+
+        uploadCourseRepository.delete(uploadCourse);
+        myCourseService.deleteHiddenUploadCopy(hiddenCopy);
+
+        if (!imageS3Keys.isEmpty()) {
+            eventPublisher.publishEvent(new UploadCourseImagesCleanupEvent(imageS3Keys));
+        }
+        eventPublisher.publishEvent(new UploadCourseDeletedEvent(uploadCourseId));
+    }
+
+    /**
+     * 커밋 확정 후에만 캐시를 지운다 — 커밋 전에 지우면 그 사이 다른 요청이 캐시 미스를 겪고
+     * 곧 사라질 구 데이터를 다시 채워 넣는 race condition이 생길 수 있다(토스뱅크 캐시 적용기 사례).
+     * 캐시 삭제(DEL 2건 + 조건부 evict)는 명령 자체가 가벼워 동기로 처리해도 응답 시간에 미치는
+     * 영향이 미미하다 — S3 정리(비동기)와는 별도 이벤트/리스너로 관심사를 분리한다.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    void invalidateDeletedUploadCourseCaches(UploadCourseDeletedEvent event) {
+        Long uploadCourseId = event.uploadCourseId();
+        evictSingleKey(detailCacheKeyBytes(uploadCourseId), "상세 캐시");
+        evictSingleKey(itemCacheKeyBytes(uploadCourseId), "아이템 캐시");
+        evictRankingCacheIfMember(uploadCourseId);
+    }
+
+    private void evictSingleKey(byte[] key, String cacheLabel) {
+        try {
+            cacheValueRedisTemplate.execute((RedisCallback<Object>) connection -> {
+                connection.keyCommands().del(key);
+                return null;
+            });
+        } catch (Exception e) {
+            // fail-open: 삭제된 코스가 조회되면 DB에서도 이미 사라졌으므로 404로 자연히 걸러진다
+            log.warn("{} 삭제 실패.", cacheLabel, e);
+        }
+    }
+
+    /**
+     * 랭킹 캐시는 무조건 전체 clear하지 않고, 삭제된 코스가 실제로 캐시된 top5에 들어있는
+     * 테마 캐시만 골라서 evict한다. 테마 개수가 적어(mood 카테고리 enum 크기로 고정) 멤버십
+     * 확인 비용은 무시할 수준인 반면, 삭제되는 코스의 절대다수는 애초에 인기순위 밖이라
+     * 무조건 clear하면 무관한 테마까지 불필요하게 콜드 미스로 만들어 버린다.
+     * evict는 리스트를 4개로 patch하는 게 아니라 키 자체를 지우는 방식이라 "top5→top4로 줄어든
+     * 채 방치되는" 문제가 없다 — evict된 테마는 다음 조회 때 computePopularCourseIdsWithLock()이
+     * 분산락 보호 하에 정확한 top5를 다시 채운다.
+     */
+    private void evictRankingCacheIfMember(Long uploadCourseId) {
+        Cache cache = cacheManager.getCache(POPULAR_COURSES_CACHE);
+        if (cache == null) {
+            return;
+        }
+
+        List<String> candidateCacheKeys = new ArrayList<>();
+        candidateCacheKeys.add(ALL_THEME_CACHE_KEY);
+        for (KeywordType theme : KeywordType.findByCategory("mood")) {
+            candidateCacheKeys.add(theme.name());
+        }
+
+        for (String cacheKey : candidateCacheKeys) {
+            List<Long> cachedIds = readRankingCache(cacheKey);
+            if (cachedIds == null || !cachedIds.contains(uploadCourseId)) {
+                continue;
+            }
+            try {
+                cache.evict(cacheKey);
+            } catch (Exception e) {
+                log.warn("인기 랭킹 캐시 evict 실패. cacheKey={}", cacheKey, e);
+            }
+        }
+    }
+
+    /**
+     * 커밋 확정 후 S3 이미지 정리를 요청 스레드에서 분리해 삭제 API의 응답 시간이 이미지
+     * 개수에 비례해 늘어나지 않도록 한다. 실패한 key는 WARN 로그만 남기고 나머지는 계속
+     * 진행한다(fail-open).
+     */
+    @Async("courseImageCleanupExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    void cleanupDeletedUploadCourseImages(UploadCourseImagesCleanupEvent event) {
+        for (String key : event.imageS3Keys()) {
+            try {
+                s3Service.deleteFile(key);
+            } catch (Exception e) {
+                log.warn("업로드 코스 삭제 후 S3 이미지 정리 실패. key={}", key, e);
+            }
+        }
     }
 
     @Override

--- a/src/main/java/backend/yourtrip/global/config/AsyncConfig.java
+++ b/src/main/java/backend/yourtrip/global/config/AsyncConfig.java
@@ -1,0 +1,33 @@
+package backend.yourtrip.global.config;
+
+import java.util.concurrent.ThreadPoolExecutor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+/**
+ * 코스 삭제 시 자식 이미지가 많아도 API 응답 시간이 늘어나지 않도록, S3 정리처럼 외부 I/O가
+ * 섞인 후처리를 요청 스레드에서 분리하기 위한 전용 스레드풀. DB 삭제(cascade)는 자식 row 수가
+ * 적어(코스 1건당 최대 수백 건 수준) 이 규모에서는 동기로 유지해도 무방하지만, 이미지마다
+ * 개별 네트워크 호출이 필요한 S3 삭제는 이미지 개수에 비례해 응답이 늘어질 수 있어 분리한다.
+ */
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "courseImageCleanupExecutor")
+    public ThreadPoolTaskExecutor courseImageCleanupExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        // S3 삭제는 네트워크 I/O 대기가 대부분이라 CPU 코어 수보다 넉넉하게 잡아도 이득이 있다.
+        executor.setCorePoolSize(4);
+        executor.setMaxPoolSize(8);
+        executor.setQueueCapacity(200);
+        // 큐가 가득 차면 호출 스레드가 직접 실행 — 응답 자체를 막지는 않되(이미 커밋 이후 시점),
+        // 무한정 쌓이는 것보다 자연스럽게 degrade하는 편이 안전하다.
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        executor.setThreadNamePrefix("course-image-cleanup-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/backend/yourtrip/global/exception/errorCode/UploadCourseErrorCode.java
+++ b/src/main/java/backend/yourtrip/global/exception/errorCode/UploadCourseErrorCode.java
@@ -12,7 +12,7 @@ public enum UploadCourseErrorCode implements ErrorCode {
     INVALID_SORT_TYPE("올바르지 않는 정렬 기준입니다.", HttpStatus.BAD_REQUEST),
     COURSE_ALREADY_UPLOAD("이미 업로드된 코스입니다.", HttpStatus.BAD_REQUEST),
     INVALID_THEME_TYPE("올바르지 않은 테마입니다.", HttpStatus.BAD_REQUEST),
-    NOT_OWNED_UPLOAD_COURSE("본인이 업로드한 코스만 수정할 수 있습니다.", HttpStatus.FORBIDDEN);
+    NOT_OWNED_UPLOAD_COURSE("본인이 업로드한 코스만 수정/삭제할 수 있습니다.", HttpStatus.FORBIDDEN);
 
     private final String message;
     private final HttpStatus status;

--- a/src/test/java/backend/yourtrip/domain/mycourse/service/MyCourseServiceImplTest.java
+++ b/src/test/java/backend/yourtrip/domain/mycourse/service/MyCourseServiceImplTest.java
@@ -1,8 +1,11 @@
 package backend.yourtrip.domain.mycourse.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import backend.yourtrip.domain.mycourse.dto.response.DayScheduleResponse;
 import backend.yourtrip.domain.mycourse.dto.response.PlaceImageResponse;
@@ -12,6 +15,7 @@ import backend.yourtrip.domain.mycourse.entity.place.Place;
 import backend.yourtrip.domain.mycourse.entity.place.PlaceImage;
 import backend.yourtrip.domain.mycourse.entity.travelCourse.TravelCourse;
 import backend.yourtrip.domain.mycourse.entity.travelCourse.enums.TravelCourseType;
+import backend.yourtrip.domain.mycourse.event.MyCourseImagesCleanupEvent;
 import backend.yourtrip.domain.mycourse.repository.DayScheduleRepository;
 import backend.yourtrip.domain.mycourse.repository.PlaceImageRepository;
 import backend.yourtrip.domain.mycourse.repository.PlaceRepository;
@@ -22,12 +26,14 @@ import backend.yourtrip.domain.user.service.UserService;
 import backend.yourtrip.global.cloudfront.service.CloudFrontService;
 import backend.yourtrip.global.exception.BusinessException;
 import backend.yourtrip.global.exception.errorCode.CloudFrontErrorCode;
+import backend.yourtrip.global.exception.errorCode.MyCourseErrorCode;
 import backend.yourtrip.global.gemini.service.GeminiService;
 import backend.yourtrip.global.kakao.KakaoLocalClient;
 import backend.yourtrip.global.s3.service.S3Service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.lang.reflect.Field;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -39,8 +45,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 /**
@@ -73,6 +81,8 @@ class MyCourseServiceImplTest {
     private UploadCourseRepository uploadCourseRepository;
     @Mock
     private KakaoLocalClient kakaoLocalClient;
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     private ThreadPoolTaskExecutor cloudFrontSigningExecutor;
     private MyCourseServiceImpl myCourseService;
@@ -95,7 +105,7 @@ class MyCourseServiceImplTest {
             userService, s3Service, cloudFrontService, geminiService, objectMapper,
             travelCourseRepository, dayScheduleRepository, placeRepository,
             placeImageRepository, uploadCourseRepository, kakaoLocalClient,
-            cloudFrontSigningExecutor
+            cloudFrontSigningExecutor, eventPublisher
         );
     }
 
@@ -211,6 +221,85 @@ class MyCourseServiceImplTest {
         assertThat(response.places().get(0).placeImages())
             .extracting(PlaceImageResponse::placeImageUrl)
             .containsExactlyInAnyOrder("signed-ok-1", "signed-ok-2");
+    }
+
+    @Test
+    @DisplayName("코스 소유자가 삭제하면 cascade delete되고, 장소 이미지가 있으면 S3 정리 이벤트가 발행된다")
+    void deleteCourse_Success_PublishesImageCleanupEvent() {
+        // given
+        DaySchedule daySchedule = daySchedule();
+        Place place = place(daySchedule, 1L);
+        addImage(place, 11L, "k1");
+        addImage(place, 12L, "k2");
+        daySchedule.getPlaces().add(place);
+        TravelCourse travelCourse = daySchedule.getCourse();
+
+        given(travelCourseRepository.existsById(COURSE_ID)).willReturn(true);
+        given(travelCourseRepository.existsByIdAndUser_Id(COURSE_ID, OWNER_ID)).willReturn(true);
+        given(userService.getCurrentUserId()).willReturn(OWNER_ID);
+        given(travelCourseRepository.findCourseWithDaySchedule(COURSE_ID))
+            .willReturn(Optional.of(travelCourse));
+        given(dayScheduleRepository.findDaySchedulesWithPlaces(COURSE_ID))
+            .willReturn(List.of(daySchedule));
+
+        // when
+        myCourseService.deleteCourse(COURSE_ID);
+
+        // then
+        verify(travelCourseRepository).delete(travelCourse);
+        ArgumentCaptor<MyCourseImagesCleanupEvent> captor =
+            ArgumentCaptor.forClass(MyCourseImagesCleanupEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        assertThat(captor.getValue().imageS3Keys()).containsExactlyInAnyOrder("k1", "k2");
+    }
+
+    @Test
+    @DisplayName("장소 이미지가 없는 코스를 삭제하면 S3 정리 이벤트를 발행하지 않는다")
+    void deleteCourse_NoImages_DoesNotPublishCleanupEvent() {
+        // given
+        DaySchedule daySchedule = daySchedule();
+        TravelCourse travelCourse = daySchedule.getCourse();
+
+        given(travelCourseRepository.existsById(COURSE_ID)).willReturn(true);
+        given(travelCourseRepository.existsByIdAndUser_Id(COURSE_ID, OWNER_ID)).willReturn(true);
+        given(userService.getCurrentUserId()).willReturn(OWNER_ID);
+        given(travelCourseRepository.findCourseWithDaySchedule(COURSE_ID))
+            .willReturn(Optional.of(travelCourse));
+        given(dayScheduleRepository.findDaySchedulesWithPlaces(COURSE_ID))
+            .willReturn(List.of(daySchedule));
+
+        // when
+        myCourseService.deleteCourse(COURSE_ID);
+
+        // then
+        verify(travelCourseRepository).delete(travelCourse);
+        verify(eventPublisher, never()).publishEvent(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 코스를 삭제하려 하면 COURSE_NOT_FOUND 예외가 발생한다")
+    void deleteCourse_CourseNotFound_ThrowsException() {
+        // given
+        given(travelCourseRepository.existsById(COURSE_ID)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> myCourseService.deleteCourse(COURSE_ID))
+            .isInstanceOf(BusinessException.class)
+            .hasFieldOrPropertyWithValue("errorCode", MyCourseErrorCode.COURSE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("소유하지 않은 코스를 삭제하려 하면 NOT_OWNED_COURSE 예외가 발생한다")
+    void deleteCourse_NotOwner_ThrowsException() {
+        // given
+        given(travelCourseRepository.existsById(COURSE_ID)).willReturn(true);
+        given(travelCourseRepository.existsByIdAndUser_Id(COURSE_ID, OWNER_ID)).willReturn(false);
+        given(userService.getCurrentUserId()).willReturn(OWNER_ID);
+
+        // when & then
+        assertThatThrownBy(() -> myCourseService.deleteCourse(COURSE_ID))
+            .isInstanceOf(BusinessException.class)
+            .hasFieldOrPropertyWithValue("errorCode", MyCourseErrorCode.NOT_OWNED_COURSE);
     }
 
     private DaySchedule daySchedule() {

--- a/src/test/java/backend/yourtrip/domain/uploadcourse/controller/UploadCourseControllerE2ETest.java
+++ b/src/test/java/backend/yourtrip/domain/uploadcourse/controller/UploadCourseControllerE2ETest.java
@@ -5,6 +5,8 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -230,5 +232,32 @@ class UploadCourseControllerE2ETest {
                 .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
             .andDo(print())
             .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("DELETE /api/upload-courses/{uploadCourseId} - 로그인한 사용자가 삭제 요청 시 204 No Content를 반환하고 서비스에 위임한다")
+    @WithMockUser
+    void deleteUploadCourse_Success() throws Exception {
+        // given
+        Long uploadCourseId = 1L;
+
+        // when & then
+        mockMvc.perform(delete("/api/upload-courses/{uploadCourseId}", uploadCourseId))
+            .andDo(print())
+            .andExpect(status().isNoContent());
+
+        verify(uploadCourseService).deleteUploadCourse(uploadCourseId);
+    }
+
+    @Test
+    @DisplayName("DELETE /api/upload-courses/{uploadCourseId} - 비인증 사용자가 요청 시 401/403 응답을 반환한다")
+    void deleteUploadCourse_Unauthenticated_ReturnsForbiddenOrUnauthorized() throws Exception {
+        // given
+        Long uploadCourseId = 1L;
+
+        // when & then
+        mockMvc.perform(delete("/api/upload-courses/{uploadCourseId}", uploadCourseId))
+            .andDo(print())
+            .andExpect(status().is4xxClientError());
     }
 }

--- a/src/test/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseServiceImplTest.java
+++ b/src/test/java/backend/yourtrip/domain/uploadcourse/service/UploadCourseServiceImplTest.java
@@ -3,12 +3,16 @@ package backend.yourtrip.domain.uploadcourse.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import backend.yourtrip.domain.mycourse.dto.response.DayScheduleResponse;
 import backend.yourtrip.domain.mycourse.entity.dayschedule.DaySchedule;
 import backend.yourtrip.domain.mycourse.entity.place.Place;
+import backend.yourtrip.domain.mycourse.entity.place.PlaceImage;
 import backend.yourtrip.domain.mycourse.entity.travelCourse.TravelCourse;
 import backend.yourtrip.domain.mycourse.entity.travelCourse.enums.TravelCourseType;
 import backend.yourtrip.domain.mycourse.service.MyCourseService;
@@ -19,6 +23,8 @@ import backend.yourtrip.domain.uploadcourse.dto.response.UploadCourseDetailRespo
 import backend.yourtrip.domain.uploadcourse.entity.UploadCourse;
 import backend.yourtrip.domain.uploadcourse.entity.enums.KeywordType;
 import backend.yourtrip.domain.uploadcourse.event.UploadCourseCacheRefreshEvent;
+import backend.yourtrip.domain.uploadcourse.event.UploadCourseDeletedEvent;
+import backend.yourtrip.domain.uploadcourse.event.UploadCourseImagesCleanupEvent;
 import backend.yourtrip.domain.uploadcourse.repository.UploadCourseRepository;
 import backend.yourtrip.domain.user.entity.User;
 import backend.yourtrip.domain.user.service.UserService;
@@ -35,9 +41,11 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -278,6 +286,167 @@ class UploadCourseServiceImplTest {
 
         // then
         verify(uploadCourseViewCountService).incrementViewCountIfNotDuplicate(uploadCourseId, viewerKey);
+    }
+
+    @Test
+    @DisplayName("작성자가 아닌 사용자가 업로드 코스 삭제를 시도하면 NOT_OWNED_UPLOAD_COURSE 예외가 발생한다")
+    void deleteUploadCourse_NotOwner_ThrowsException() {
+        // given
+        Long uploadCourseId = 1L;
+        Long ownerId = 10L;
+        Long otherUserId = 20L;
+
+        User owner = User.builder().email("owner@test.com").password("pass").nickname("owner").build();
+        setEntityId(owner, ownerId);
+
+        TravelCourse travelCourse = TravelCourse.builder()
+            .user(owner).title("t").location("경주")
+            .startDate(LocalDate.now()).endDate(LocalDate.now())
+            .type(TravelCourseType.UPLOADED)
+            .build();
+        setEntityId(travelCourse, 100L);
+
+        UploadCourse uploadCourse = UploadCourse.builder()
+            .title("t").introduction("소개").thumbnailImageS3Key("thumb.png")
+            .travelCourse(travelCourse).user(owner).location("경주")
+            .build();
+
+        given(uploadCourseRepository.findWithTravelCourseAndKeywords(uploadCourseId))
+            .willReturn(Optional.of(uploadCourse));
+        given(userService.getCurrentUserId()).willReturn(otherUserId);
+
+        // when & then
+        assertThatThrownBy(() -> uploadCourseService.deleteUploadCourse(uploadCourseId))
+            .isInstanceOf(BusinessException.class)
+            .hasFieldOrPropertyWithValue("errorCode", UploadCourseErrorCode.NOT_OWNED_UPLOAD_COURSE);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 업로드 코스를 삭제하려 하면 UPLOAD_COURSE_NOT_FOUND 예외가 발생한다")
+    void deleteUploadCourse_NotFound_ThrowsException() {
+        // given
+        given(uploadCourseRepository.findWithTravelCourseAndKeywords(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> uploadCourseService.deleteUploadCourse(1L))
+            .isInstanceOf(BusinessException.class)
+            .hasFieldOrPropertyWithValue("errorCode", UploadCourseErrorCode.UPLOAD_COURSE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("작성자가 업로드 코스를 삭제하면 hidden copy까지 함께 삭제되고 S3/Redis 이벤트가 발행된다")
+    void deleteUploadCourse_Success_DeletesHiddenCopyAndPublishesEvents() {
+        // given
+        Long uploadCourseId = 1L;
+        Long ownerId = 10L;
+
+        User owner = User.builder().email("owner@test.com").password("pass").nickname("owner").build();
+        setEntityId(owner, ownerId);
+
+        TravelCourse travelCourse = TravelCourse.builder()
+            .user(owner).title("t").location("경주")
+            .startDate(LocalDate.now()).endDate(LocalDate.now())
+            .type(TravelCourseType.UPLOADED)
+            .build();
+        setEntityId(travelCourse, 100L);
+
+        DaySchedule daySchedule = DaySchedule.builder().course(travelCourse).day(1).build();
+        setEntityId(daySchedule, 1000L);
+        Place place = Place.builder()
+            .daySchedule(daySchedule).placeName("황리단길")
+            .latitude(35.8).longitude(129.2)
+            .placeUrl("url").placeLocation("경주")
+            .build();
+        setEntityId(place, 2000L);
+        PlaceImage image = new PlaceImage(place, "place-key.jpg");
+        setEntityId(image, 3000L);
+        place.getPlaceImages().add(image);
+        daySchedule.getPlaces().add(place);
+
+        UploadCourse uploadCourse = UploadCourse.builder()
+            .title("t").introduction("소개").thumbnailImageS3Key("thumb.png")
+            .travelCourse(travelCourse).user(owner).location("경주")
+            .build();
+
+        given(uploadCourseRepository.findWithTravelCourseAndKeywords(uploadCourseId))
+            .willReturn(Optional.of(uploadCourse));
+        given(userService.getCurrentUserId()).willReturn(ownerId);
+        given(myCourseService.getDaySchedulesWithPlaces(100L)).willReturn(List.of(daySchedule));
+
+        // when
+        uploadCourseService.deleteUploadCourse(uploadCourseId);
+
+        // then
+        verify(uploadCourseRepository).delete(uploadCourse);
+        verify(myCourseService).deleteHiddenUploadCopy(travelCourse);
+        verify(eventPublisher).publishEvent(ArgumentMatchers.<Object>argThat(event ->
+            event instanceof UploadCourseImagesCleanupEvent imagesEvent
+                && imagesEvent.imageS3Keys().size() == 2
+                && imagesEvent.imageS3Keys().containsAll(List.of("thumb.png", "place-key.jpg"))
+        ));
+        verify(eventPublisher).publishEvent(ArgumentMatchers.<Object>argThat(event ->
+            event instanceof UploadCourseDeletedEvent deletedEvent
+                && deletedEvent.uploadCourseId().equals(uploadCourseId)
+        ));
+    }
+
+    @Test
+    @DisplayName("기본 썸네일만 있고 장소 이미지가 없으면 S3 정리 이벤트를 발행하지 않는다")
+    void deleteUploadCourse_DefaultThumbnailAndNoImages_DoesNotPublishCleanupEvent() {
+        // given
+        Long uploadCourseId = 1L;
+        Long ownerId = 10L;
+
+        User owner = User.builder().email("owner@test.com").password("pass").nickname("owner").build();
+        setEntityId(owner, ownerId);
+
+        TravelCourse travelCourse = TravelCourse.builder()
+            .user(owner).title("t").location("경주")
+            .startDate(LocalDate.now()).endDate(LocalDate.now())
+            .type(TravelCourseType.UPLOADED)
+            .build();
+        setEntityId(travelCourse, 100L);
+
+        UploadCourse uploadCourse = UploadCourse.builder()
+            .title("t").introduction("소개").thumbnailImageS3Key("default-upload-course-thumbnail.png")
+            .travelCourse(travelCourse).user(owner).location("경주")
+            .build();
+
+        given(uploadCourseRepository.findWithTravelCourseAndKeywords(uploadCourseId))
+            .willReturn(Optional.of(uploadCourse));
+        given(userService.getCurrentUserId()).willReturn(ownerId);
+        given(myCourseService.getDaySchedulesWithPlaces(100L)).willReturn(List.of());
+
+        // when
+        uploadCourseService.deleteUploadCourse(uploadCourseId);
+
+        // then
+        verify(eventPublisher, never()).publishEvent(any(UploadCourseImagesCleanupEvent.class));
+        verify(eventPublisher).publishEvent(any(UploadCourseDeletedEvent.class));
+    }
+
+    @Test
+    @DisplayName("삭제된 코스가 캐시된 인기 랭킹에 있는 테마만 골라서 evict하고, 없는 테마는 건드리지 않는다")
+    void invalidateDeletedUploadCourseCaches_EvictsOnlyMatchingThemeCache() {
+        // given
+        Long uploadCourseId = 42L;
+        Cache popularCoursesCache = mock(Cache.class);
+        given(cacheManager.getCache("popularCourses")).willReturn(popularCoursesCache);
+        // ALL 캐시에는 삭제된 코스가 포함되어 있고, FOOD 캐시에는 포함되어 있지 않다.
+        // 나머지 mood 테마 캐시는 stub하지 않아 mock 기본값(null)이 반환되며,
+        // 이는 "해당 테마는 캐시 미스"로 취급되어 evict 대상에서 자연히 제외된다.
+        given(popularCoursesCache.get(eq("ALL"), eq(List.class)))
+            .willReturn(List.of(42L, 7L, 8L, 9L, 10L));
+        given(popularCoursesCache.get(eq("FOOD"), eq(List.class)))
+            .willReturn(List.of(1L, 2L, 3L, 4L, 5L));
+
+        // when
+        uploadCourseService.invalidateDeletedUploadCourseCaches(
+            new UploadCourseDeletedEvent(uploadCourseId));
+
+        // then
+        verify(popularCoursesCache).evict("ALL");
+        verify(popularCoursesCache, never()).evict("FOOD");
     }
 
     private void setEntityId(Object entity, Long id) {


### PR DESCRIPTION
## ✅ 작업 내용

### 나의 코스 삭제
- `DELETE /api/my-courses/{courseId}`로 코스를 삭제할 수 있다
- 코스에 속한 일차/장소/장소이미지가 cascade로 함께 삭제되고, S3에 업로드된 장소 이미지 파일도 정리된다(응답 시간에 영향 없도록 커밋 후 비동기 처리)
- 이미 업로드된 원본이어도 삭제가 차단되지 않는다 — uploadCourse는 업로드 시점에 복제된 독립 데이터라 원본을 지워도 이미 공개된 uploadCourse는 그대로 유지된다

### 업로드 코스 삭제
- `DELETE /api/upload-courses/{uploadCourseId}`로 업로드 코스를 삭제할 수 있다
- 업로드 코스와 그 뒤에 숨은 사본(hidden copy mycourse)이 함께 정리되며, 썸네일/장소 이미지도 S3에서 비동기로 정리된다
- 삭제 즉시 Redis 캐시가 무효화되어 삭제 직후 상세 조회/인기 목록에 더 이상 노출되지 않는다
  - 상세/아이템 캐시는 무조건 DEL
  - 인기 랭킹 캐시는 삭제된 코스가 실제로 캐시된 테마만 골라 evict하고, 무관한 테마 캐시는 건드리지 않아 불필요한 재계산을 방지한다

## 📌 관련 이슈

관련 이슈 없음

## 📚 추가 리팩토링 가능성

- `deleted` 필드 + `@SQLRestriction`을 살려 소프트 삭제로 전환하는 방안 (복구/법적 보관 요건이 생기면 유효)
- S3 개별 `deleteFile()` 반복 호출을 AWS `DeleteObjects` 배치 API(최대 1,000키/요청)로 교체 — 이미지 수가 많아지는 시나리오에서 유효
- 데이터 규모가 커지면 `@OnDelete(action = OnDeleteAction.CASCADE)` 또는 QueryDSL bulk delete로 cascade 삭제 성능 개선 검토
- 원본 mycourse ↔ uploadCourse 간 명시적 FK 링크를 추가해, 향후 "원본 삭제 시 업로드도 함께 삭제할지" 같은 정책 변경에 대비