### PR TITLE
feat: EC2+RDS+ElastiCache 분리 부하테스트 인프라 구축

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,28 @@ terraform/*_override.tf
 terraform/*_override.tf.json
 terraform/.terraformrc
 terraform/terraform.rc
+
+### Terraform (loadtest 루트 모듈 — 별도 state, 위와 동일한 패턴) ###
+terraform/loadtest/.terraform/
+terraform/loadtest/.terraform.lock.hcl
+terraform/loadtest/*.tfstate
+terraform/loadtest/*.tfstate.*
+terraform/loadtest/*.tfvars
+terraform/loadtest/*.tfplan
+terraform/loadtest/tfplan*
+terraform/loadtest/crash.log
+terraform/loadtest/*.pem
+terraform/loadtest/*.pub
+# ssh-keygen 기본 산출물은 개인키에 확장자가 없다(공개키만 .pub) — 이름 패턴으로 추가 차단.
+terraform/loadtest/*-ssh
+terraform/loadtest/crash.*.log
+terraform/loadtest/override.tf
+terraform/loadtest/override.tf.json
+terraform/loadtest/*_override.tf
+terraform/loadtest/*_override.tf.json
+terraform/loadtest/.terraformrc
+terraform/loadtest/terraform.rc
+# terraform apply/plan 실행 시 로컬에 남는 운영 로그 — 민감정보 포함 가능성 있고
+# 애초에 버전관리 대상도 아니다.
+terraform/loadtest/apply*.log
+terraform/loadtest/*.output

--- a/docs/guide/EC2-RDS-LOADTEST-GUIDE.md
+++ b/docs/guide/EC2-RDS-LOADTEST-GUIDE.md
@@ -1,0 +1,206 @@
+# EC2 + RDS + ElastiCache 분리 배포 환경 부하테스트 가이드
+
+## 배경
+
+[TASK-PRESIGN-BOTTLENECK-FIX.md의 "개선 제안 — 배포 환경(EC2 + RDS) 분리 부하테스트"](../tasks/TASK-PRESIGN-BOTTLENECK-FIX.md)가 지목한 문제 — 지금까지의 모든 부하테스트가 앱·PostgreSQL·Redis·Prometheus·Grafana·k6를 전부 로컬 개발 노트북 한 대에서 동시에 돌린 결과라, "인덱스 추가 이후 남은 병목이 진짜 구조적 문제(HikariCP 20:1 풀 크기)인지, 로컬 머신의 CPU 경합 노이즈인지" 구분이 안 됐다 — 를 해소하기 위해 앱은 EC2, DB는 RDS, 캐시는 ElastiCache, 부하생성기는 별도 EC2로 분리한 환경이다.
+
+이 문서는 그 분리 환경이 **이미 배포된 이후**의 부하테스트 실행 절차(Prometheus 재조준 → k6 실행 → 병목 확인 → 지표 측정)를 다룬다. 인프라를 처음부터 구축/재구축하는 절차(Terraform apply/destroy)는 [terraform/loadtest/README.md](../../terraform/loadtest/README.md)를 따로 참고한다 — 이 문서와 역할이 겹치지 않게 분리했다.
+
+## 1. 배포 환경 구성요소
+
+| 리소스 | 스펙 | 역할 |
+|---|---|---|
+| VPC (전용) | `10.42.0.0/16`, 단일 AZ(`ap-northeast-2a`) 배치 | 계정 기본 VPC에 의존하지 않는 격리된 네트워크. 모든 컴퓨트 리소스를 한 AZ에 몰아 네트워크 변수를 최소화 |
+| App EC2 | `t3.micro` | 실제 배포 타겟과 동일 스펙. Spring Boot 앱(JVM)만 단독 실행 — Redis/모니터링과 분리해 "1GB로 버티는가"를 순수하게 검증 |
+| k6 EC2 | `t3.micro` | 부하생성기 전용. 앱/DB와 물리적으로 분리해 부하생성기 자신이 CPU 경합을 일으키던 로컬 환경의 문제를 재현하지 않는다 |
+| RDS PostgreSQL | `db.t3.micro`, 단일 AZ | 로컬 시드 규모(course 6,000행, place 30,000행, place_image 60,000행)에 충분. `publicly_accessible=false` — **로컬에서 직접 접속 불가**(§7 참고) |
+| ElastiCache Redis | `cache.t3.micro`, 단일 노드 | 로컬 `docker-compose.yml`의 Redis(`maxmemory 256mb`, `allkeys-lru`)에 대응하는 관리형 대체 |
+| Prometheus / Grafana | **EC2에 배치하지 않음** — 로컬 개발 머신 그대로 유지 | 측정 대상이 아니라 관측자이므로 어디서 실행되든 지표 값은 동일하다. EC2에 같이 올리면 이번 실험이 없애려던 "여러 프로세스가 CPU를 나눠 쓰는" 문제를 다시 만드는 셈이라 의도적으로 분리했다 |
+
+**현재 값은 재배포하면 바뀐다** — 아래는 특정 시점의 스냅샷이며, 항상 `terraform output`으로 최신 값을 다시 확인한다.
+
+```bash
+cd terraform/loadtest
+terraform output
+```
+
+## 2. 사전 준비 확인
+
+인프라가 이미 떠 있고 앱이 정상 기동했는지 먼저 확인한다.
+
+```bash
+curl -sf http://<App EC2 공인 IP>:8080/actuator/health
+```
+
+`{"status":"UP", "components":{"db":{"status":"UP"...}, "redis":{"status":"UP"...}}}`가 나와야 한다. 안 뜬다면 §7의 트러블슈팅부터 확인한다.
+
+**DB 시딩 여부도 확인한다** — RDS는 `publicly_accessible=false`라 로컬에서 직접 `psql` 접속이 안 되므로, 시딩은 App EC2를 경유해서 한다(§7 참고). 이미 시딩했다면 재실행 전 반드시 재시딩(`TRUNCATE` 후 재삽입, `scripts/sql/seed-benchmark.sql` 자체가 이를 수행)해 로컬 벤치마크와 동일한 조건을 유지한다.
+
+## 3. 로컬 Prometheus/Grafana 원격 재조준
+
+Prometheus는 능동적으로 5초마다 대상 주소에 HTTP GET을 날려 지표를 긁어오는 구조([prometheus.yml](../../prometheus.yml))라, 대상 주소만 바꾸면 실행 위치는 로컬에 둔 채로 원격의 App EC2를 관측할 수 있다.
+
+```diff
+  - job_name: 'presign'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+-     - targets: ['host.docker.internal:8080']
++     - targets: ['<App EC2 공인 IP>:8080']
+```
+
+```bash
+docker compose up -d prometheus grafana
+```
+
+**확인**: `http://localhost:9090` → `Status` → `Targets`에서 `presign` job이 `UP`인지 확인한다(`cloudfront` job은 이번 환경에서 쓰지 않으므로 `DOWN`이 정상 — [MONITORING-GUIDE.md](MONITORING-GUIDE.md) §3-2 참고).
+
+Grafana(`localhost:3000`, admin/admin)는 아무것도 바꿀 필요 없다 — `Dashboards → Bottleneck Test → Presign CPU Bottleneck`에서 그대로 확인 가능([MONITORING-GUIDE.md](MONITORING-GUIDE.md) §4 참고).
+
+**측정이 끝나면 반드시 원상복구한다**:
+
+```bash
+git checkout -- prometheus.yml
+```
+
+## 4. k6 부하테스트 실행
+
+k6 EC2에 SSH로 접속해 실행한다(k6가 로컬이 아니라 별도 EC2에 있는 이유는 §1 참고).
+
+```bash
+cd terraform/loadtest
+ssh -i ./yourtrip-loadtest-ssh ec2-user@<k6 EC2 공인 IP>
+```
+
+접속 후, App EC2를 대상으로 mycourse/uploadcourse 각각 ramping 프로파일(VU 1→200, 450초, [LOAD-TESTING-GUIDE.md §6](LOAD-TESTING-GUIDE.md) 참고)을 실행한다:
+
+```bash
+cd /opt/app
+k6 run -e BASE_URL=http://<App EC2 공인 IP>:8080 -e DOMAIN=uploadcourse -e MODE=pool scripts/k6/detail-ramping.js
+k6 run -e BASE_URL=http://<App EC2 공인 IP>:8080 -e DOMAIN=mycourse   -e MODE=pool scripts/k6/detail-ramping.js
+```
+
+- `MODE=pool`: course_id를 2~3000 범위에서 무작위 선택 — 캐시가 고르게 데워지는 실제 트래픽에 가까운 패턴
+- 두 도메인을 동시에 돌리지 않는다 — 로컬 벤치마크와 동일하게 순차 실행해야 지표가 섞이지 않는다
+- 실행 중에는 §3에서 열어둔 Grafana 대시보드를 "Last 15 minutes" + 5초 auto-refresh로 관찰한다
+
+## 5. 병목 지점 확인 방법
+
+### 5-1. Prometheus에서 직접 확인 (`http://localhost:9090`)
+
+| 지표 | PromQL | 의미 |
+|---|---|---|
+| 대기 중인 커넥션 요청 수 | `hikaricp_connections_pending{pool="HikariPool-1"}` | **0을 넘기 시작하는 시점이 포화의 첫 신호** — TPS/CPU가 눈에 띄게 나빠지기 전에 가장 먼저 반응한다 |
+| 활성 커넥션 수 | `hikaricp_connections_active{pool="HikariPool-1"}` | 풀 크기(기본 10)에 도달했는지 확인 |
+| 커넥션 점유시간 최댓값 | `hikaricp_connections_acquire_seconds_max{pool="HikariPool-1"}` | 롤링 윈도우 최댓값이라 절대 최댓값은 아님 — 추세 확인용 |
+| 평균 커넥션 점유시간(더 정확함) | `rate(hikaricp_connections_usage_seconds_sum{pool="HikariPool-1"}[1m]) / rate(hikaricp_connections_usage_seconds_count{pool="HikariPool-1"}[1m])` | `_max`보다 신뢰도 높은 지표 — 카운터형이라 구간 평균을 정확히 계산할 수 있다 |
+| JVM CPU 사용률 | `process_cpu_usage` | 이 프로세스만의 CPU — 낮은데 지연이 커지면 CPU 병목이 아니라는 뜻 |
+| 시스템 전체 CPU | `system_cpu_usage` | App EC2 인스턴스 전체 CPU — `process_cpu_usage`와 같이 봐야 "다른 프로세스가 CPU를 뺏는지" 판단 가능. 이 환경은 앱만 단독 실행되므로 로컬과 달리 이 둘의 차이가 거의 없어야 정상 |
+| Tomcat 활성 스레드 | `tomcat_threads_busy_threads` | `maxThreads`(기본 200)에 도달했는지 — 도달했다면 대부분의 요청 스레드가 DB를 기다리며 멈춰있다는 뜻 |
+
+### 5-2. 포화 시작 VU(knee) 판정
+
+`hikaricp_connections_pending`이 0을 넘기 시작하는 시점을 k6 ramping 스테이지 경계(60/60/60/90/90/90초 = VU 5/10/20/50/100/200)와 대조해 "몇 VU부터 포화가 시작됐는가"를 특정한다. [LOAD-TESTING-GUIDE.md §6](LOAD-TESTING-GUIDE.md)의 knee 개념과 동일한 방법론이다.
+
+### 5-3. CloudWatch에서 확인 (환경 자체의 한계 여부 판별용)
+
+로컬 실측에서 "인덱스로 쿼리는 49~236배 빨라졌는데 풀 포화 지표는 그대로였던" 원인이 로컬 머신의 CPU 공유 문제였다는 게 JFR로 밝혀졌었다([TASK-PRESIGN-BOTTLENECK-FIX.md](../tasks/TASK-PRESIGN-BOTTLENECK-FIX.md) Phase C 참고). 이번 환경에서 같은 종류의 잡음이 남아있는지는 CloudWatch로 확인한다.
+
+```bash
+# App EC2 메모리 사용률 (커스텀 네임스페이스 — CloudWatch Agent가 수집)
+AWS_PROFILE=terraform-admin aws cloudwatch get-metric-statistics \
+  --namespace YourtripLoadtest --metric-name mem_used_percent \
+  --dimensions Name=InstanceId,Value=<App EC2 instance ID> \
+  --start-time <ISO8601> --end-time <ISO8601> --period 30 --statistics Maximum
+
+# 버스터블(t3) 인스턴스 CPU 크레딧 잔량 — App EC2/k6 EC2/RDS/ElastiCache 전부 확인
+AWS_PROFILE=terraform-admin aws cloudwatch get-metric-statistics \
+  --namespace AWS/EC2 --metric-name CPUCreditBalance \
+  --dimensions Name=InstanceId,Value=<인스턴스 ID> \
+  --start-time <ISO8601> --end-time <ISO8601> --period 60 --statistics Minimum
+```
+
+`CPUCreditBalance`가 테스트 도중 0에 가까워지면, "로컬 CPU 경합"이 "AWS 크레딧 고갈"이라는 같은 종류의 새 병목으로 바뀐 것뿐이라는 뜻이다 — 이 경우 이번 측정 결과의 신뢰도를 재평가해야 한다.
+
+## 6. 성능 지표 측정 및 로컬 대비 비교
+
+측정한 값을 아래 표에 채워 로컬 실측치(인덱스 추가 후, [TASK-PRESIGN-BOTTLENECK-FIX.md](../tasks/TASK-PRESIGN-BOTTLENECK-FIX.md) "인덱스 추가 결과" 참고)와 비교한다.
+
+### mycourse (DB 접근이 필수인 경로 — 핵심 비교 대상)
+
+| | TPS | p95 | `pending` 최대 | `acquire_seconds` 최대 | 포화 시작 VU |
+|---|---|---|---|---|---|
+| 로컬(인덱스 후, 비격리 환경) | 110.89/s | 1.63s | 181 | 2.7286s | VU~20 |
+| **EC2+RDS 분리 환경(이번 측정)** | | | | | |
+
+### uploadcourse (캐시 히트 위주 — 참고용, 원래도 풀 경합 없었음)
+
+| | TPS | p95 | `pending` 최대 |
+|---|---|---|---|
+| 로컬(인덱스 후) | 1,760.8/s | 71.02ms | 0 |
+| **EC2+RDS 분리 환경(이번 측정)** | | | |
+
+**판정 기준**:
+- mycourse의 포화 시작 VU가 20보다 뚜렷이 뒤로 밀리거나 `acquire_seconds`/`pending`이 크게 줄었다면 → 로컬에서 관찰된 잔여 병목은 **환경 노이즈였음이 확정**된다.
+- 거의 변화가 없다면 → TASK-PRESIGN-BOTTLENECK-FIX.md 4단계(HikariCP 풀 크기 재검토)가 **진짜 구조적 병목**이라는 뜻이다.
+
+## 7. 트러블슈팅 — 실측으로 발견된 함정
+
+이 환경을 처음 구축하며 실제로 겪은 문제들이다. 재배포 시 다시 마주칠 수 있어 기록해둔다.
+
+### 7-1. `git clone --branch <커밋 SHA> --depth 1` 실패
+
+`app_git_ref`에 브랜치명이 아니라 커밋 해시를 넘기면 `fatal: Remote branch <sha> not found in upstream origin`로 실패한다 — 이 조합은 브랜치/태그 이름만 지원한다. `terraform/loadtest/templates/app-user-data.sh.tpl`/`k6-user-data.sh.tpl`에서 `git init` + `git fetch --depth 1 origin <SHA>` + `git checkout FETCH_HEAD` 방식으로 이미 수정 반영됨(GitHub 공개 저장소는 임의 SHA fetch를 허용).
+
+### 7-2. k6 rpm 저장소 404
+
+`baseurl=https://dl.k6.io/rpm`을 직접 가리키는 `.repo` 파일 방식은 `repodata/repomd.xml`이 404다. `dnf install -y https://dl.k6.io/rpm/repo.rpm`(공식 문서 기준 최신 방법)으로 이미 수정 반영됨.
+
+### 7-3. CloudFront 개인키 없이는 앱이 기동 자체를 못 함
+
+`CloudFrontService` 빈 초기화가 개인키 파일을 필수로 요구해서, 개인키 전달 전에는 `systemctl enable --now`가 무한 크래시 루프(`Restart=on-failure`)를 돈다 — "나중에 해도 되는 선택적 단계"가 아니라 **앱 기동의 필수 선행조건**이다.
+
+```bash
+scp -i ./yourtrip-loadtest-ssh ../cloudfront_private_key.pem \
+  ec2-user@<App EC2 공인 IP>:/opt/app/cloudfront_private_key.pem
+
+ssh -i ./yourtrip-loadtest-ssh ec2-user@<App EC2 공인 IP> \
+  'sudo chown ec2-user:ec2-user /opt/app/cloudfront_private_key.pem && \
+   sudo chmod 600 /opt/app/cloudfront_private_key.pem && \
+   sudo systemctl restart yourtrip-app.service'
+```
+
+### 7-4. RDS `publicly_accessible=false` — 로컬에서 직접 `psql` 불가
+
+`allow_dev_psql_access=true`로 보안그룹을 열어도 소용없다 — RDS 엔드포인트 DNS 자체가 VPC 사설 IP로만 resolve되기 때문에(`publicly_accessible=false`), 인터넷에서 그 IP로 가는 경로가 애초에 없다. 반드시 같은 VPC 안의 App EC2를 경유한다:
+
+```bash
+scp -i ./yourtrip-loadtest-ssh ../../scripts/sql/seed-benchmark.sql \
+  ec2-user@<App EC2 공인 IP>:/tmp/seed-benchmark.sql
+
+ssh -i ./yourtrip-loadtest-ssh ec2-user@<App EC2 공인 IP> 'sudo dnf install -y postgresql16'
+
+ssh -i ./yourtrip-loadtest-ssh ec2-user@<App EC2 공인 IP> \
+  "PGPASSWORD='<rds_password>' psql -h <RDS 엔드포인트> -U postgres -d yourtrip -f /tmp/seed-benchmark.sql"
+```
+
+### 7-5. `aws_security_group`(rule 아님)의 `description`에 한글을 쓰면 apply가 실패함
+
+`terraform validate`로는 안 잡히고 실제 `apply` 시점에 `InvalidParameterValue: ... Character sets beyond ASCII are not supported`로 실패한다. `aws_security_group_rule`뿐 아니라 `aws_security_group` 자체의 `description`도 ASCII만 허용된다 — `terraform/loadtest/security_groups.tf`는 전부 영문으로 이미 수정됨.
+
+## 8. 측정 종료 후 정리
+
+```bash
+# 1. 로컬 prometheus.yml 원상복구
+git checkout -- prometheus.yml
+
+# 2. 인프라 철거 (비용 최소화 — 임시 인프라이므로 측정 후 즉시 철거)
+cd terraform/loadtest
+AWS_PROFILE=terraform-admin terraform destroy
+```
+
+## 참고 문서
+
+- [terraform/loadtest/README.md](../../terraform/loadtest/README.md) — 인프라 구축/철거 절차(이 문서와 역할 분리)
+- [TASK-PRESIGN-BOTTLENECK-FIX.md](../tasks/TASK-PRESIGN-BOTTLENECK-FIX.md) — 이 부하테스트의 목적이 된 로컬 실측 기록과 비교 기준
+- [LOAD-TESTING-GUIDE.md](LOAD-TESTING-GUIDE.md) — k6/JFR 사용법 전반
+- [MONITORING-GUIDE.md](MONITORING-GUIDE.md) — Prometheus/Grafana 구축 및 기본 사용법

--- a/terraform/loadtest/README.md
+++ b/terraform/loadtest/README.md
@@ -1,0 +1,172 @@
+# Terraform — EC2 + RDS + ElastiCache 분리 부하테스트 환경
+
+이 디렉토리는 [`docs/tasks/TASK-PRESIGN-BOTTLENECK-FIX.md`](../../docs/tasks/TASK-PRESIGN-BOTTLENECK-FIX.md)의
+"개선 제안 — 배포 환경(EC2 + RDS) 분리 부하테스트" 절을 실행하기 위한 **일회성·임시 인프라**를 관리한다.
+로컬 개발 노트북(12코어) 한 대에서 앱·DB·Redis·k6를 전부 같이 돌리며 생긴 CPU 경합 노이즈를 제거하고,
+`hikaricp_connections_pending`/`acquire_seconds` 병목이 진짜 구조적 문제인지 환경 잡음이었는지를 확정하는 게 목적이다.
+
+**기존 [`terraform/`](../README.md)(S3·CloudFront·IAM, 영구 인프라)와는 완전히 분리된 별도 state를 쓴다.**
+이 인프라는 측정 후 바로 `destroy`하는 용도라, 영구 인프라와 state를 공유하면 실수로 함께 날아갈 위험이 있다.
+
+## 아키텍처 요약
+
+| 리소스 | 스펙 | 비고 |
+|---|---|---|
+| VPC (전용) | `10.42.0.0/16` | 계정 기본 VPC 유무에 의존하지 않음. public subnet 2개(AZ 요구조건 충족용), 실제 배치는 전부 1개 AZ로 고정 |
+| App EC2 | `t3.micro` | 실제 배포 타겟과 동일 스펙. 앱(JVM) 단독 실행 |
+| k6 EC2 | `t3.micro` | 부하 생성 전용. Redis를 ElastiCache로 분리해 경합 상대 없음 |
+| RDS PostgreSQL | `db.t3.micro` | 단일 AZ, 로컬 시드 규모(course 6,000행 등)에 여유 |
+| ElastiCache Redis | `cache.t3.micro` | 단일 노드. Docker Redis(`maxmemory 256mb`, `allkeys-lru`)의 관리형 대체 |
+
+Prometheus·Grafana는 **EC2에 올리지 않는다** — 기존 로컬 `docker-compose.yml`을 그대로 쓰되 스크레이프 대상만 App EC2로 바꾼다(아래 5번).
+
+## 사전 준비
+
+### 1. SSH 키페어 생성
+
+```bash
+ssh-keygen -t ed25519 -f ./yourtrip-loadtest-ssh -C yourtrip-loadtest
+```
+
+CloudFront 서명용 키페어와는 무관한, 이번 EC2 SSH 접속 전용 키다. `.pem`/`.pub` 모두 `.gitignore`로 보호된다.
+
+### 2. 기존 `terraform/` output 값 확인
+
+App EC2가 실행하는 애플리케이션은 S3/CloudFront에 접근해야 하므로, 기존 영구 인프라의 output을 재사용한다(이 모듈이 S3/CloudFront를 새로 만들지 않는다):
+
+```bash
+terraform -chdir=../ output -raw s3_bucket_name
+terraform -chdir=../ output -raw iam_user_access_key_id
+terraform -chdir=../ output -raw iam_user_secret_access_key
+terraform -chdir=../ output -raw cloudfront_domain_name
+terraform -chdir=../ output -raw cloudfront_key_pair_id
+terraform -chdir=../ output -raw cloudfront_distribution_id
+```
+
+### 3. `terraform.tfvars` 작성
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+curl -s ifconfig.me   # my_ip_cidr에 /32 붙여서 채우기
+```
+
+`terraform.tfvars.example`의 주석을 따라 나머지 값(2번에서 확인한 값들, `rds_password`, `jwt_secret` 등)을 채운다.
+
+### 4. 로컬 PostgreSQL 버전 확인
+
+```bash
+psql --version
+```
+
+`terraform.tfvars`의 `rds_engine_version`을 이 버전(major)에 맞춘다 — 로컬 대비 배율 비교의 기준을 맞추기 위함이다.
+
+### 5. AWS 프리티어 잔여량 확인
+
+AWS 콘솔 → Billing → Free Tier에서 EC2(t3.micro)/RDS(db.t3.micro)/ElastiCache(cache.t3.micro) 프리티어 자격이 남아있는지 확인한다. (`enable_detailed_monitoring`은 프리티어 대상이 아니라 소액 과금이 있다 — 몇 시간짜리 테스트라면 센트 단위.)
+
+## 실행 순서
+
+### 1. apply
+
+```bash
+terraform init
+terraform plan -out=tfplan
+terraform apply tfplan
+```
+
+```bash
+terraform output -raw app_public_ip
+terraform output -raw k6_public_ip
+terraform output -raw rds_endpoint
+```
+
+### 2. CloudFront 개인키 전달
+
+앱이 mycourse Signed URL을 서명하려면 개인키가 필요하다. Terraform state에는 절대 넣지 않으므로(기존 `terraform/README.md`와 동일 원칙) 수동으로 옮긴다:
+
+```bash
+scp -i ./yourtrip-loadtest-ssh ../cloudfront_private_key.pem \
+  ec2-user@$(terraform output -raw app_public_ip):/opt/app/cloudfront_private_key.pem
+
+ssh -i ./yourtrip-loadtest-ssh ec2-user@$(terraform output -raw app_public_ip) \
+  'sudo systemctl restart yourtrip-app.service'
+```
+
+### 3. 앱 기동 확인
+
+```bash
+curl -sf http://$(terraform output -raw app_public_ip):8080/actuator/health
+```
+
+`{"status":"UP"}`가 나올 때까지 대기한다(`user_data`의 Gradle 빌드가 완료되는 데 몇 분 걸릴 수 있다 — `ssh`로 접속해 `journalctl -u yourtrip-app -f`로 진행 상황을 볼 수 있다).
+
+### 4. DB 시딩
+
+**RDS는 `publicly_accessible = false`라 로컬에서 직접 접속할 수 없다** — `allow_dev_psql_access`로 보안그룹을 열어도, 엔드포인트 DNS 자체가 VPC 사설 IP(예: `10.42.1.x`)로만 resolve되기 때문에 인터넷에서 그 IP로 가는 경로가 없다(실측으로 확인됨). 반드시 같은 VPC 안의 App EC2를 경유한다:
+
+```bash
+# 1. 시드 스크립트를 App EC2로 전달
+scp -i ./yourtrip-loadtest-ssh ../../scripts/sql/seed-benchmark.sql \
+  ec2-user@$(terraform output -raw app_public_ip):/tmp/seed-benchmark.sql
+
+# 2. App EC2에 psql 클라이언트 설치 (최초 1회)
+ssh -i ./yourtrip-loadtest-ssh ec2-user@$(terraform output -raw app_public_ip) \
+  'sudo dnf install -y postgresql16'
+
+# 3. App EC2에서 RDS로 시딩 실행 (같은 VPC라 sg-rds가 sg-app을 허용)
+ssh -i ./yourtrip-loadtest-ssh ec2-user@$(terraform output -raw app_public_ip) \
+  "PGPASSWORD='<rds_password>' psql -h $(terraform output -raw rds_endpoint) -U postgres -d yourtrip -f /tmp/seed-benchmark.sql"
+```
+
+### 5. 로컬 Prometheus/Grafana를 원격 App EC2로 재조준
+
+`prometheus.yml`(레포 루트)의 스크레이프 대상을 바꾼다:
+
+```diff
+- targets: ['host.docker.internal:8080']
++ targets: ['<terraform output -raw app_public_ip>:8080']
+```
+
+```bash
+docker compose up -d prometheus grafana
+```
+
+Grafana(`localhost:3000`)의 Dashboards → Bottleneck Test → Presign CPU Bottleneck에서 그대로 확인 가능하다.
+
+### 6. k6 부하테스트 실행
+
+```bash
+ssh -i ./yourtrip-loadtest-ssh ec2-user@$(terraform output -raw k6_public_ip)
+```
+
+접속 후:
+
+```bash
+cd /opt/app
+k6 run -e BASE_URL=http://<App EC2 공인 IP>:8080 -e DOMAIN=uploadcourse -e MODE=pool scripts/k6/detail-ramping.js
+k6 run -e BASE_URL=http://<App EC2 공인 IP>:8080 -e DOMAIN=mycourse -e MODE=pool scripts/k6/detail-ramping.js
+```
+
+### 7. 지표 수집
+
+- Prometheus range query: `hikaricp_connections_pending`, `hikaricp_connections_acquire_seconds_max`, `hikaricp_connections_active`
+- CloudWatch: App EC2 `mem_used_percent`(커스텀 네임스페이스 `YourtripLoadtest`), App EC2/k6 EC2/RDS/ElastiCache `CPUCreditBalance`, `CPUUtilization`
+
+로컬 실측치(포화 시작 VU~20, `acquire_seconds` 최대 2.7초)와 비교한다.
+
+### 8. 원상복구 및 철거
+
+```bash
+# 저장소 루트에서
+git checkout -- prometheus.yml
+
+# 이 디렉토리에서
+terraform destroy
+```
+
+## 알아둬야 할 것
+
+- **`rds_password`, `jwt_secret` 등 민감값은 `terraform.tfstate`에 평문으로 저장된다.** 기존 `terraform/`과 동일한 트레이드오프이며(로컬 state, remote backend 없음), 테스트 종료 후 `terraform destroy`로 리소스 자체를 없애는 것이 최선의 완화책이다.
+- **App EC2 사용자 데이터가 빌드 중 임시 스왑(1GB)을 켰다가 끈다.** 부하테스트를 시작하기 전 스왑이 꺼져 있는지 `free -h`로 확인하는 걸 권장한다 — 켜진 채로 측정하면 "1GB로 버티는가"라는 핵심 질문이 디스크 I/O 지연으로 왜곡된다.
+- **`DB_DDL_AUTO=create`를 쓴다** — 이 RDS는 매 측정 전 재시딩하는 테스트 전용 DB라, 로컬 벤치마크와 동일하게 스키마를 앱이 직접 생성하게 둔다. 운영 DB(`validate`)와는 다른 설정임을 인지하고 있을 것.
+- **버스터블(t3) 인스턴스 4개 전부 CPU 크레딧 고갈 가능성이 있다.** `CPUCreditBalance`가 0에 가까워지면 "로컬 CPU 경합"이 "AWS 크레딧 고갈"이라는 같은 종류의 새로운 병목으로 바뀐 것뿐이므로, 이 경우 측정 신뢰도를 재평가해야 한다.

--- a/terraform/loadtest/ec2_app.tf
+++ b/terraform/loadtest/ec2_app.tf
@@ -1,0 +1,58 @@
+data "aws_ami" "al2023" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-2023.*-x86_64"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+}
+
+resource "aws_instance" "app" {
+  ami                         = data.aws_ami.al2023.id
+  instance_type               = var.app_instance_type
+  subnet_id                   = aws_subnet.primary.id
+  vpc_security_group_ids      = [aws_security_group.app.id]
+  key_name                    = aws_key_pair.ssh.key_name
+  iam_instance_profile        = aws_iam_instance_profile.app_ec2.name
+  monitoring                  = var.enable_detailed_monitoring
+  associate_public_ip_address = true
+
+  # 기본 루트 볼륨(8GB)은 Gradle 의존성 캐시+빌드 산출물까지 감안하면 빠듯할 수 있어
+  # 여유를 둔다. gp3 15GB는 프리티어(월 30GB gp2/gp3 무료) 안에 충분히 들어온다.
+  root_block_device {
+    volume_size = 15
+    volume_type = "gp3"
+  }
+
+  # RDS/ElastiCache 엔드포인트가 필요하므로 두 리소스가 먼저 생성돼야 한다.
+  user_data = templatefile("${path.module}/templates/app-user-data.sh.tpl", {
+    app_repo_url               = var.app_repo_url
+    app_git_ref                = var.app_git_ref
+    db_host                    = aws_db_instance.this.address
+    db_name                    = var.rds_db_name
+    db_username                = var.rds_username
+    db_password                = var.rds_password
+    jwt_secret                 = var.jwt_secret
+    mail_email                 = var.mail_email
+    mail_password              = var.mail_password
+    kakao_api_key              = var.kakao_api_key
+    s3_bucket                  = var.s3_bucket
+    aws_access_key             = var.aws_access_key
+    aws_secret_key             = var.aws_secret_key
+    cloudfront_domain          = var.cloudfront_domain
+    cloudfront_key_pair_id     = var.cloudfront_key_pair_id
+    cloudfront_distribution_id = var.cloudfront_distribution_id
+    gemini_api_key             = var.gemini_api_key
+    redis_host                 = aws_elasticache_cluster.this.cache_nodes[0].address
+  })
+
+  tags = {
+    Name = "${var.name_prefix}-app"
+  }
+}

--- a/terraform/loadtest/ec2_k6.tf
+++ b/terraform/loadtest/ec2_k6.tf
@@ -1,0 +1,18 @@
+resource "aws_instance" "k6" {
+  ami                         = data.aws_ami.al2023.id
+  instance_type               = var.k6_instance_type
+  subnet_id                   = aws_subnet.primary.id
+  vpc_security_group_ids      = [aws_security_group.k6.id]
+  key_name                    = aws_key_pair.ssh.key_name
+  monitoring                  = var.enable_detailed_monitoring
+  associate_public_ip_address = true
+
+  user_data = templatefile("${path.module}/templates/k6-user-data.sh.tpl", {
+    app_repo_url = var.app_repo_url
+    app_git_ref  = var.app_git_ref
+  })
+
+  tags = {
+    Name = "${var.name_prefix}-k6"
+  }
+}

--- a/terraform/loadtest/elasticache.tf
+++ b/terraform/loadtest/elasticache.tf
@@ -1,0 +1,42 @@
+resource "aws_elasticache_subnet_group" "this" {
+  name       = "${var.name_prefix}-redis-subnet-group"
+  subnet_ids = [aws_subnet.primary.id, aws_subnet.secondary.id]
+}
+
+# maxmemory-policy만 오버라이드 — 로컬 docker-compose.yml의
+# `redis-server --maxmemory-policy allkeys-lru`와 동일한 축출 정책을 관리형에서도 유지한다
+# (순수 캐시라 원본은 항상 DB에 있음, CACHING-ROADMAP.md 설계 원칙 참고).
+# maxmemory 자체는 오버라이드하지 않는다 — ElastiCache는 노드 타입별 예약 메모리를
+# 제외한 나머지를 자동으로 maxmemory로 산정해주므로 수동 설정이 오히려 위험하다.
+resource "aws_elasticache_parameter_group" "this" {
+  name   = "${var.name_prefix}-redis7-params"
+  family = "redis7"
+
+  parameter {
+    name  = "maxmemory-policy"
+    value = "allkeys-lru"
+  }
+}
+
+resource "aws_elasticache_cluster" "this" {
+  cluster_id           = "${var.name_prefix}-redis"
+  engine               = "redis"
+  engine_version       = "7.1"
+  node_type            = var.elasticache_node_type
+  num_cache_nodes      = 1
+  port                 = 6379
+  parameter_group_name = aws_elasticache_parameter_group.this.name
+  subnet_group_name    = aws_elasticache_subnet_group.this.name
+  security_group_ids   = [aws_security_group.elasticache.id]
+
+  # 순수 캐시(원본은 항상 DB)이고 이번 인프라는 측정 후 즉시 철거하는 일회성
+  # 테스트라 스냅샷 자체가 불필요하다 — fork 기반 메모리 스파이크 리스크를
+  # 원천 차단하는 효과도 있다(자체 호스팅 Redis였다면 --save "" 에 해당).
+  snapshot_retention_limit = 0
+
+  apply_immediately = true
+
+  tags = {
+    Name = "${var.name_prefix}-redis"
+  }
+}

--- a/terraform/loadtest/iam.tf
+++ b/terraform/loadtest/iam.tf
@@ -1,0 +1,28 @@
+# App EC2 전용 IAM 역할 — CloudWatch Agent가 mem_used_percent(메모리 사용률)를
+# 게시할 수 있게 해준다. 기본 CloudWatch 지표는 EC2 메모리를 노출하지 않아서,
+# "t3.micro 1GB로 JVM+Tomcat 200스레드가 버티는가"를 실측으로 확인하려면 이 권한이 필수다.
+data "aws_iam_policy_document" "ec2_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "app_ec2" {
+  name               = "${var.name_prefix}-app-ec2-role"
+  assume_role_policy = data.aws_iam_policy_document.ec2_assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "app_ec2_cloudwatch_agent" {
+  role       = aws_iam_role.app_ec2.name
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+}
+
+resource "aws_iam_instance_profile" "app_ec2" {
+  name = "${var.name_prefix}-app-ec2-profile"
+  role = aws_iam_role.app_ec2.name
+}

--- a/terraform/loadtest/key_pair.tf
+++ b/terraform/loadtest/key_pair.tf
@@ -1,0 +1,12 @@
+# CloudFront 서명용 키페어(terraform/)와는 완전히 별개의, EC2 SSH 접속 전용 키페어.
+# 개인키는 로컬에서 별도로 생성해 var.ssh_public_key_path가 그 공개키(.pub)를 가리키게 한다
+# (예: ssh-keygen -t ed25519 -f ./yourtrip-loadtest-ssh -C yourtrip-loadtest).
+# 개인키 파일 자체는 terraform/loadtest/*.pem으로 저장해도 .gitignore에 걸린다.
+resource "aws_key_pair" "ssh" {
+  key_name   = "${var.name_prefix}-ssh"
+  public_key = file(var.ssh_public_key_path)
+
+  tags = {
+    Name = "${var.name_prefix}-ssh"
+  }
+}

--- a/terraform/loadtest/outputs.tf
+++ b/terraform/loadtest/outputs.tf
@@ -1,0 +1,29 @@
+output "app_public_ip" {
+  description = "App EC2 공인 IP — 로컬 prometheus.yml 스크레이프 타겟, Swagger 접속, k6 BASE_URL에 사용"
+  value       = aws_instance.app.public_ip
+}
+
+output "app_ssh_command" {
+  description = "App EC2 SSH 접속 명령 (<SSH 개인키 경로>를 실제 경로로 바꿔서 사용)"
+  value       = "ssh -i <SSH 개인키 경로> ec2-user@${aws_instance.app.public_ip}"
+}
+
+output "k6_public_ip" {
+  description = "k6 EC2 공인 IP"
+  value       = aws_instance.k6.public_ip
+}
+
+output "k6_ssh_command" {
+  description = "k6 EC2 SSH 접속 명령 (<SSH 개인키 경로>를 실제 경로로 바꿔서 사용)"
+  value       = "ssh -i <SSH 개인키 경로> ec2-user@${aws_instance.k6.public_ip}"
+}
+
+output "rds_endpoint" {
+  description = "psql -h <이 값> -U <rds_username> -d <rds_db_name>로 seed-benchmark.sql 실행 시 사용"
+  value       = aws_db_instance.this.address
+}
+
+output "redis_endpoint" {
+  description = "ElastiCache 엔드포인트. App EC2의 .env REDIS_HOST에 자동으로 주입되므로 참고/디버깅용."
+  value       = aws_elasticache_cluster.this.cache_nodes[0].address
+}

--- a/terraform/loadtest/provider.tf
+++ b/terraform/loadtest/provider.tf
@@ -1,0 +1,14 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project   = "yourtrip"
+      Component = "loadtest"
+      ManagedBy = "terraform"
+      # 이 인프라는 측정 후 즉시 destroy하는 일회성 환경임을 태그로도 명시해,
+      # 콘솔에서 실수로 영구 리소스로 착각하고 남겨두는 걸 방지한다.
+      Ephemeral = "true"
+    }
+  }
+}

--- a/terraform/loadtest/rds.tf
+++ b/terraform/loadtest/rds.tf
@@ -1,0 +1,42 @@
+resource "aws_db_subnet_group" "this" {
+  name       = "${var.name_prefix}-rds-subnet-group"
+  subnet_ids = [aws_subnet.primary.id, aws_subnet.secondary.id]
+
+  tags = {
+    Name = "${var.name_prefix}-rds-subnet-group"
+  }
+}
+
+resource "aws_db_instance" "this" {
+  identifier     = "${var.name_prefix}-postgres"
+  engine         = "postgres"
+  engine_version = var.rds_engine_version
+  instance_class = var.rds_instance_class
+
+  allocated_storage = 20
+  storage_type      = "gp2"
+
+  db_name  = var.rds_db_name
+  username = var.rds_username
+  password = var.rds_password
+
+  db_subnet_group_name   = aws_db_subnet_group.this.name
+  vpc_security_group_ids = [aws_security_group.rds.id]
+  availability_zone      = var.availability_zone_primary
+
+  multi_az            = false
+  publicly_accessible = false
+  storage_encrypted   = false
+
+  # 로컬 벤치마크와 동일하게 매 측정 전 seed-benchmark.sql로 재시딩하는 일회성
+  # 테스트 DB라 자동 백업/최종 스냅샷이 불필요하다 — 관리 부담과 destroy 소요
+  # 시간만 늘어난다(운영 DB였다면 이 설정들은 절대 이렇게 두면 안 된다).
+  backup_retention_period = 0
+  skip_final_snapshot     = true
+  deletion_protection     = false
+  apply_immediately       = true
+
+  tags = {
+    Name = "${var.name_prefix}-postgres"
+  }
+}

--- a/terraform/loadtest/security_groups.tf
+++ b/terraform/loadtest/security_groups.tf
@@ -1,0 +1,154 @@
+resource "aws_security_group" "app" {
+  name        = "${var.name_prefix}-sg-app"
+  description = "App EC2 - Spring Boot API + Actuator"
+  vpc_id      = aws_vpc.this.id
+
+  tags = {
+    Name = "${var.name_prefix}-sg-app"
+  }
+}
+
+resource "aws_security_group" "k6" {
+  name        = "${var.name_prefix}-sg-k6"
+  description = "Dedicated EC2 for k6 load generator"
+  vpc_id      = aws_vpc.this.id
+
+  tags = {
+    Name = "${var.name_prefix}-sg-k6"
+  }
+}
+
+resource "aws_security_group" "rds" {
+  name        = "${var.name_prefix}-sg-rds"
+  description = "RDS PostgreSQL"
+  vpc_id      = aws_vpc.this.id
+
+  tags = {
+    Name = "${var.name_prefix}-sg-rds"
+  }
+}
+
+resource "aws_security_group" "elasticache" {
+  name        = "${var.name_prefix}-sg-elasticache"
+  description = "ElastiCache Redis"
+  vpc_id      = aws_vpc.this.id
+
+  tags = {
+    Name = "${var.name_prefix}-sg-elasticache"
+  }
+}
+
+# ---------------- app ----------------
+
+resource "aws_security_group_rule" "app_ingress_api_from_k6" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.app.id
+  from_port                = 8080
+  to_port                  = 8080
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.k6.id
+  description              = "Load traffic from k6 EC2"
+}
+
+resource "aws_security_group_rule" "app_ingress_api_from_dev" {
+  type              = "ingress"
+  security_group_id = aws_security_group.app.id
+  from_port         = 8080
+  to_port           = 8080
+  protocol          = "tcp"
+  cidr_blocks       = [var.my_ip_cidr]
+  description       = "Remote Prometheus scrape (/actuator/prometheus) + manual Swagger check from dev machine"
+}
+
+resource "aws_security_group_rule" "app_ingress_ssh_from_dev" {
+  type              = "ingress"
+  security_group_id = aws_security_group.app.id
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = [var.my_ip_cidr]
+  description       = "SSH for troubleshooting and CloudFront private key delivery"
+}
+
+resource "aws_security_group_rule" "app_egress_all" {
+  type              = "egress"
+  security_group_id = aws_security_group.app.id
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+# ---------------- k6 ----------------
+
+resource "aws_security_group_rule" "k6_ingress_ssh_from_dev" {
+  type              = "ingress"
+  security_group_id = aws_security_group.k6.id
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = [var.my_ip_cidr]
+  description       = "SSH to log in and run k6"
+}
+
+resource "aws_security_group_rule" "k6_egress_all" {
+  type              = "egress"
+  security_group_id = aws_security_group.k6.id
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+# ---------------- rds ----------------
+
+resource "aws_security_group_rule" "rds_ingress_from_app" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.rds.id
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.app.id
+  description              = "HikariCP connections from the app"
+}
+
+resource "aws_security_group_rule" "rds_ingress_from_dev" {
+  count             = var.allow_dev_psql_access ? 1 : 0
+  type              = "ingress"
+  security_group_id = aws_security_group.rds.id
+  from_port         = 5432
+  to_port           = 5432
+  protocol          = "tcp"
+  cidr_blocks       = [var.my_ip_cidr]
+  description       = "Direct psql access for EXPLAIN ANALYZE etc. (optional, toggled by allow_dev_psql_access)"
+}
+
+resource "aws_security_group_rule" "rds_egress_all" {
+  type              = "egress"
+  security_group_id = aws_security_group.rds.id
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+# ---------------- elasticache ----------------
+
+resource "aws_security_group_rule" "elasticache_ingress_from_app" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.elasticache.id
+  from_port                = 6379
+  to_port                  = 6379
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.app.id
+  description              = "Cache lookups from the app"
+}
+
+resource "aws_security_group_rule" "elasticache_egress_all" {
+  type              = "egress"
+  security_group_id = aws_security_group.elasticache.id
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+}

--- a/terraform/loadtest/templates/app-user-data.sh.tpl
+++ b/terraform/loadtest/templates/app-user-data.sh.tpl
@@ -1,0 +1,114 @@
+#!/bin/bash
+# App EC2 부트스트랩 — Amazon Linux 2023
+# 이 파일은 Terraform templatefile()로 렌더링된다. 중괄호로 감싼 변수 참조는 전부
+# Terraform 변수 치환 대상이고, 순수 bash 변수는 $VAR(중괄호 없이)로만 참조해 충돌을 피한다.
+set -euxo pipefail
+
+dnf install -y java-21-amazon-corretto-devel git amazon-cloudwatch-agent
+
+# --- 빌드 시 메모리 스파이크 대비 임시 스왑 ---
+# t3.micro는 RAM 1GB뿐이라 Gradle 빌드(의존성 다운로드+컴파일)가 OOM으로 죽을 위험이 있다.
+# 빌드 동안만 스왑을 켜고, 실제 부하테스트를 시작하기 전에 반드시 끈다 — 스왑을 켜둔 채
+# 측정하면 디스크 I/O 지연이 섞여 "1GB로 버티는가"라는 이번 실험의 핵심 질문이 왜곡된다.
+fallocate -l 1G /swapfile
+chmod 600 /swapfile
+mkswap /swapfile
+swapon /swapfile
+
+# --- 앱 체크아웃 & 빌드 ---
+# app_git_ref는 브랜치명이 아니라 커밋 해시일 수 있다. `git clone --branch --depth 1`은
+# 브랜치/태그 이름만 지원하고 임의 커밋 SHA는 실패한다(실측으로 확인된 버그 —
+# "Remote branch <sha> not found in upstream origin"). init+remote+fetch by SHA는
+# 브랜치명/SHA 둘 다 지원하고, GitHub은 공개 저장소에 대해 임의 SHA fetch를 허용한다.
+mkdir -p /opt/app
+cd /opt/app
+git init -q
+git remote add origin "${app_repo_url}"
+git fetch --depth 1 origin "${app_git_ref}"
+git checkout -q FETCH_HEAD
+chmod +x gradlew
+./gradlew bootJar -x test --no-daemon
+
+JAR_PATH=$(find build/libs -maxdepth 1 -name '*.jar' ! -name '*-plain.jar' | head -n1)
+mv "$JAR_PATH" /opt/app/app.jar
+
+# --- 빌드 완료, 스왑 해제 (실측 왜곡 방지) ---
+swapoff /swapfile
+rm -f /swapfile
+
+# --- 런타임 환경변수 ---
+# CloudFront 개인키는 기존 terraform/README.md와 동일한 원칙으로 Terraform state에
+# 절대 넣지 않는다. apply 이후 `scp`로 로컬의 cloudfront_private_key.pem을 아래 경로로
+# 직접 옮겨야 한다 (README.md "실행 순서" 참고).
+cat > /opt/app/.env <<'ENVEOF'
+DB_URL=jdbc:postgresql://${db_host}:5432/${db_name}
+DB_USERNAME=${db_username}
+DB_PASSWORD=${db_password}
+DB_DDL_AUTO=create
+JWT_SECRET=${jwt_secret}
+MAIL_EMAIL=${mail_email}
+MAIL_PASSWORD=${mail_password}
+KAKAO_API_KEY=${kakao_api_key}
+S3_BUCKET=${s3_bucket}
+AWS_ACCESS_KEY=${aws_access_key}
+AWS_SECRET_KEY=${aws_secret_key}
+CLOUDFRONT_DOMAIN=${cloudfront_domain}
+CLOUDFRONT_KEY_PAIR_ID=${cloudfront_key_pair_id}
+CLOUDFRONT_PRIVATE_KEY_PATH=/opt/app/cloudfront_private_key.pem
+CLOUDFRONT_DISTRIBUTION_ID=${cloudfront_distribution_id}
+GEMINI_API_KEY=${gemini_api_key}
+REDIS_HOST=${redis_host}
+REDIS_PORT=6379
+ENVEOF
+chmod 600 /opt/app/.env
+
+touch /opt/app/cloudfront_private_key.pem
+chmod 600 /opt/app/cloudfront_private_key.pem
+
+# --- systemd 서비스 등록 ---
+# -Xmx448m: 1GB 중 OS(~150~200MB)+메타스페이스+Tomcat maxThreads=200 스레드 스택
+# 여유분을 남기고 힙 상한을 명시적으로 통제한다.
+# -Xss512k: 기본 1MB 대비 스레드 스택 메모리 절반(200스레드 기준 이론상 최대 200MB->100MB).
+# 너무 작으면 Hibernate처럼 콜스택이 깊은 코드에서 StackOverflowError 위험이 있으니
+# 부하테스트 중 애플리케이션 로그를 함께 확인한다.
+cat > /etc/systemd/system/yourtrip-app.service <<'SERVICEEOF'
+[Unit]
+Description=YOURTRIP Spring Boot App (loadtest)
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/app
+EnvironmentFile=/opt/app/.env
+ExecStart=/usr/bin/java -Xmx448m -Xss512k -jar /opt/app/app.jar
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+SERVICEEOF
+
+systemctl daemon-reload
+systemctl enable --now yourtrip-app.service
+
+# --- CloudWatch Agent: 메모리 지표 수집 ---
+# 기본 CloudWatch 지표는 EC2 메모리를 노출하지 않는다. mem_used_percent가 이번
+# 실험의 핵심 검증 항목(t3.micro 1GB가 실제로 버티는가) 중 하나라 필수로 켠다.
+mkdir -p /opt/aws/amazon-cloudwatch-agent/etc
+cat > /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json <<'CWEOF'
+{
+  "metrics": {
+    "namespace": "YourtripLoadtest",
+    "metrics_collected": {
+      "mem": {
+        "measurement": ["mem_used_percent"],
+        "metrics_collection_interval": 30
+      }
+    }
+  }
+}
+CWEOF
+
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
+  -a fetch-config -m ec2 -s \
+  -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json

--- a/terraform/loadtest/templates/k6-user-data.sh.tpl
+++ b/terraform/loadtest/templates/k6-user-data.sh.tpl
@@ -1,0 +1,22 @@
+#!/bin/bash
+# k6 EC2 부트스트랩 — Amazon Linux 2023
+set -euxo pipefail
+
+dnf install -y git
+
+# k6 공식 설치 방법(현재 grafana.com/docs/k6 기준) — repo.rpm 패키지가 실제 저장소 설정을
+# 등록해준다. 수동으로 baseurl=https://dl.k6.io/rpm을 직접 가리키는 .repo 파일을 작성하는
+# 방식은 해당 경로의 repodata가 404라 실패하는 것을 실측으로 확인해 이 방식으로 교체했다.
+dnf install -y https://dl.k6.io/rpm/repo.rpm
+dnf install -y k6
+
+# k6 부하 스크립트(scripts/k6/detail-ramping.js 등)만 필요하므로 shallow clone.
+# app_git_ref는 브랜치명이 아니라 커밋 해시일 수 있다. `git clone --branch --depth 1`은
+# 브랜치/태그 이름만 지원하고 임의 커밋 SHA는 실패한다(App EC2에서 실측으로 확인된 버그).
+# init+remote+fetch by SHA는 브랜치명/SHA 둘 다 지원한다.
+mkdir -p /opt/app
+cd /opt/app
+git init -q
+git remote add origin "${app_repo_url}"
+git fetch --depth 1 origin "${app_git_ref}"
+git checkout -q FETCH_HEAD

--- a/terraform/loadtest/terraform.tfvars.example
+++ b/terraform/loadtest/terraform.tfvars.example
@@ -1,0 +1,60 @@
+# terraform/loadtest/terraform.tfvars 로 복사한 뒤 실제 값을 채워 사용한다.
+# (terraform.tfvars는 git에 커밋하지 않는다)
+
+aws_region  = "ap-northeast-2"
+name_prefix = "yourtrip-loadtest"
+
+# curl -s ifconfig.me 로 확인. SSH/8080(actuator 원격 스크레이프)/선택적 5432 접근을
+# 이 IP로만 제한하는 데 쓰인다. 자택/사무실 IP가 바뀌면 apply 전에 반드시 갱신할 것.
+my_ip_cidr = "" # 예: "203.0.113.10/32"
+
+# --- 네트워크 (보통 기본값 그대로 사용) ---
+vpc_cidr                     = "10.42.0.0/16"
+public_subnet_primary_cidr   = "10.42.1.0/24"
+public_subnet_secondary_cidr = "10.42.2.0/24"
+availability_zone_primary    = "ap-northeast-2a"
+availability_zone_secondary  = "ap-northeast-2c"
+
+# --- EC2 ---
+# ssh-keygen -t ed25519 -f ./yourtrip-loadtest-ssh -C yourtrip-loadtest 로 이 디렉토리에
+# 생성한 키페어 중 공개키(.pub) 경로를 지정한다. 개인키는 .gitignore로 이미 보호된다.
+ssh_public_key_path = "./yourtrip-loadtest-ssh.pub"
+
+app_instance_type         = "t3.micro" # 실제 배포 타겟과 동일 스펙 — 임의로 올리지 말 것
+k6_instance_type          = "t3.micro" # CPU 포화 관측되면 t3.small로 올리는 걸 대안으로 검토
+enable_detailed_monitoring = true
+
+app_repo_url = "https://github.com/Kookmin-MoP-Yourtrip/YOURTRIP_BE.git"
+app_git_ref  = "" # 로컬에서 검증한 커밋 해시를 지정하는 걸 권장 (예: "e7023d1")
+
+# --- RDS ---
+rds_instance_class    = "db.t3.micro"
+rds_engine_version    = "16" # apply 전 로컬 `psql --version`으로 확인해 맞출 것
+rds_db_name            = "yourtrip"
+rds_username            = "postgres"
+rds_password            = "" # 반드시 채울 것 (state에 평문 저장됨 — terraform/README.md 트레이드오프 절 참고)
+allow_dev_psql_access   = false # EXPLAIN ANALYZE 직접 검증이 필요할 때만 true
+
+# --- ElastiCache ---
+elasticache_node_type = "cache.t3.micro"
+
+# --- 애플리케이션 환경변수 ---
+# 아래 s3_bucket ~ cloudfront_distribution_id는 기존 terraform/ apply 결과를 그대로 재사용한다:
+#   terraform -chdir=../ output -raw s3_bucket_name
+#   terraform -chdir=../ output -raw iam_user_access_key_id
+#   terraform -chdir=../ output -raw iam_user_secret_access_key
+#   terraform -chdir=../ output -raw cloudfront_domain_name
+#   terraform -chdir=../ output -raw cloudfront_key_pair_id
+#   terraform -chdir=../ output -raw cloudfront_distribution_id
+jwt_secret     = ""
+mail_email      = ""
+mail_password    = ""
+kakao_api_key     = ""
+gemini_api_key      = ""
+
+s3_bucket                  = ""
+aws_access_key              = ""
+aws_secret_key                = ""
+cloudfront_domain               = ""
+cloudfront_key_pair_id            = ""
+cloudfront_distribution_id          = ""

--- a/terraform/loadtest/variables.tf
+++ b/terraform/loadtest/variables.tf
@@ -1,0 +1,204 @@
+# ============================================================
+# 공통
+# ============================================================
+
+variable "aws_region" {
+  description = "리전. 기존 terraform/variables.tf의 S3/CloudFront 리전과 동일하게 맞춘다."
+  type        = string
+  default     = "ap-northeast-2"
+}
+
+variable "name_prefix" {
+  description = "이 모듈이 생성하는 모든 리소스 이름/태그 접두사. 기존 terraform/(영구 인프라)과 이름이 겹치지 않게 구분한다."
+  type        = string
+  default     = "yourtrip-loadtest"
+}
+
+variable "my_ip_cidr" {
+  description = "개발자의 현재 공인 IP를 CIDR 형식(예: 1.2.3.4/32)으로 지정한다. `curl -s ifconfig.me`로 확인. SSH·8080(actuator 원격 스크레이프)·(선택) 5432 접근을 이 IP로만 제한하는 데 쓰인다."
+  type        = string
+}
+
+# ============================================================
+# 네트워크 — 계정의 기본 VPC 존재 여부에 의존하지 않는 전용 VPC
+# ============================================================
+
+variable "vpc_cidr" {
+  description = "이번 부하테스트 전용 VPC의 CIDR."
+  type        = string
+  default     = "10.42.0.0/16"
+}
+
+variable "public_subnet_primary_cidr" {
+  description = "App/k6 EC2와 RDS/ElastiCache가 실제로 배치되는 주 서브넷. 모든 컴퓨트 리소스를 여기 한 AZ에 몰아 네트워크 변수를 최소화한다."
+  type        = string
+  default     = "10.42.1.0/24"
+}
+
+variable "public_subnet_secondary_cidr" {
+  description = "RDS/ElastiCache 서브넷 그룹이 AWS 제약상 요구하는 두 번째 AZ용 서브넷. 실제 인스턴스는 배치하지 않는다."
+  type        = string
+  default     = "10.42.2.0/24"
+}
+
+variable "availability_zone_primary" {
+  description = "App/k6 EC2, RDS, ElastiCache를 전부 이 AZ로 고정한다."
+  type        = string
+  default     = "ap-northeast-2a"
+}
+
+variable "availability_zone_secondary" {
+  description = "RDS/ElastiCache 서브넷 그룹용 2번째 AZ (실사용 없음)."
+  type        = string
+  default     = "ap-northeast-2c"
+}
+
+# ============================================================
+# EC2 — App / k6
+# ============================================================
+
+variable "ssh_public_key_path" {
+  description = "EC2 SSH 접속용 공개키(.pub) 파일 경로. 이번 테스트 전용 신규 키페어이며 CloudFront 서명 키페어와는 무관하다."
+  type        = string
+}
+
+variable "app_instance_type" {
+  description = "App EC2 인스턴스 타입. 실제 배포 타겟(TASK-PRESIGN-BOTTLENECK.md 확인)과 동일한 t3.micro가 기본값 — '운영 스펙이 이 부하를 버티는가'를 그대로 검증하기 위함."
+  type        = string
+  default     = "t3.micro"
+}
+
+variable "k6_instance_type" {
+  description = "k6 부하생성기 EC2 인스턴스 타입. Redis를 ElastiCache로 분리해 이 인스턴스와 경합할 상대가 없어 프리티어 t3.micro를 기본값으로 둔다. 테스트 중 CPUUtilization이 포화되면 t3.small로 올린다."
+  type        = string
+  default     = "t3.micro"
+}
+
+variable "enable_detailed_monitoring" {
+  description = "true면 CloudWatch 1분 단위 지표(기본은 5분)를 활성화한다. 부하테스트가 7.5분(450초)으로 짧아 5분 간격으로는 knee 시점을 정확히 못 잡는다 — 인스턴스당 소액 과금이 있지만(월 약 $2.1 수준, 이번처럼 몇 시간만 띄우면 사실상 센트 단위) 측정 해상도를 위해 기본값을 true로 둔다."
+  type        = bool
+  default     = true
+}
+
+variable "app_repo_url" {
+  description = "App/k6 EC2가 user_data에서 git clone할 저장소 URL."
+  type        = string
+  default     = "https://github.com/Kookmin-MoP-Yourtrip/YOURTRIP_BE.git"
+}
+
+variable "app_git_ref" {
+  description = "체크아웃할 브랜치 또는 커밋. 로컬에서 검증한 것과 동일한 코드 상태를 테스트하려면 해당 커밋 해시를 지정하는 걸 권장한다."
+  type        = string
+}
+
+# ============================================================
+# RDS
+# ============================================================
+
+variable "rds_instance_class" {
+  description = "RDS 인스턴스 클래스. db.t3.micro는 프리티어 대상이며, 로컬 시드 규모(course 6,000행 등)에 충분히 여유 있다. 버스터블 계열이라 CPUCreditBalance를 반드시 함께 모니터링한다."
+  type        = string
+  default     = "db.t3.micro"
+}
+
+variable "rds_engine_version" {
+  description = "PostgreSQL major 버전. apply 전 로컬 `psql --version`으로 실제 로컬 버전을 확인해 맞추는 걸 권장한다(로컬 대비 배율 비교의 기준을 맞추기 위함). major 버전만 지정하면 AWS가 마이너 버전은 자동으로 최신을 선택한다."
+  type        = string
+  default     = "16"
+}
+
+variable "rds_db_name" {
+  description = "생성할 데이터베이스 이름. 로컬 개발과 동일하게 yourtrip을 기본값으로 둔다."
+  type        = string
+  default     = "yourtrip"
+}
+
+variable "rds_username" {
+  description = "RDS 마스터 사용자명."
+  type        = string
+  default     = "postgres"
+}
+
+variable "rds_password" {
+  description = "RDS 마스터 비밀번호. 기본값을 두지 않아 terraform.tfvars에서 반드시 지정하도록 강제한다."
+  type        = string
+  sensitive   = true
+}
+
+variable "allow_dev_psql_access" {
+  description = "true면 개발자 공인 IP(my_ip_cidr)에서 RDS 5432 포트로의 보안그룹 인그레스를 연다. 단, RDS가 publicly_accessible=false라 엔드포인트 DNS가 VPC 사설 IP로만 resolve된다 — 실측으로 확인된 대로, 이 설정만으로는 로컬에서 직접 접속할 수 없다(보안그룹은 열려도 애초에 인터넷에서 그 사설 IP로 가는 경로 자체가 없음). 직접 psql 검증이 필요하면 App EC2에 SSH로 접속해 거기서 psql을 실행해야 한다(같은 VPC라 sg-rds가 sg-app을 허용). 이 변수는 향후 배스천 호스트나 SSM Session Manager 포트포워딩을 추가할 때를 대비해 남겨둔다."
+  type        = bool
+  default     = false
+}
+
+# ============================================================
+# ElastiCache
+# ============================================================
+
+variable "elasticache_node_type" {
+  description = "ElastiCache Redis 노드 타입. cache.t3.micro는 프리티어 대상(월 750시간, 첫 12개월 — AWS 콘솔 Billing에서 계정별 자격 확인 필요)."
+  type        = string
+  default     = "cache.t3.micro"
+}
+
+# ============================================================
+# 애플리케이션 환경변수 (.env.example 대응)
+# 대부분 기존 terraform/(S3·CloudFront·IAM)의 apply 결과(outputs)를 그대로 재사용한다 —
+# 이 모듈이 그 리소스들을 새로 만들지는 않는다.
+# ============================================================
+
+variable "jwt_secret" {
+  type      = string
+  sensitive = true
+}
+
+variable "mail_email" {
+  type = string
+}
+
+variable "mail_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "kakao_api_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "s3_bucket" {
+  description = "기존 terraform/의 output s3_bucket_name 값을 그대로 사용."
+  type        = string
+}
+
+variable "aws_access_key" {
+  description = "기존 terraform/의 output iam_user_access_key_id 값을 그대로 사용."
+  type        = string
+  sensitive   = true
+}
+
+variable "aws_secret_key" {
+  description = "기존 terraform/의 output iam_user_secret_access_key 값을 그대로 사용."
+  type        = string
+  sensitive   = true
+}
+
+variable "cloudfront_domain" {
+  description = "기존 terraform/의 output cloudfront_domain_name 값을 그대로 사용."
+  type        = string
+}
+
+variable "cloudfront_key_pair_id" {
+  description = "기존 terraform/의 output cloudfront_key_pair_id 값을 그대로 사용."
+  type        = string
+}
+
+variable "cloudfront_distribution_id" {
+  description = "기존 terraform/의 output cloudfront_distribution_id 값을 그대로 사용."
+  type        = string
+}
+
+variable "gemini_api_key" {
+  type      = string
+  sensitive = true
+}

--- a/terraform/loadtest/versions.tf
+++ b/terraform/loadtest/versions.tf
@@ -1,0 +1,12 @@
+# 기존 terraform/versions.tf와 동일한 버전 고정 정책을 그대로 따른다 — 두 루트 모듈이
+# 서로 다른 시점에 apply되더라도 동일한 provider 동작을 보장하기 위함이다.
+terraform {
+  required_version = ">= 1.9.0, < 2.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.60"
+    }
+  }
+}

--- a/terraform/loadtest/vpc.tf
+++ b/terraform/loadtest/vpc.tf
@@ -1,0 +1,69 @@
+# 계정의 기본 VPC 존재 여부에 의존하지 않는 완전히 독립된 부하테스트 전용 네트워크.
+# RDS/ElastiCache의 서브넷 그룹은 AWS 제약상 최소 2개 AZ의 서브넷이 필요해 서브넷을
+# 2개 만들지만, 실제 EC2/RDS/ElastiCache 배치는 전부 var.availability_zone_primary로
+# 고정해 인스턴스 간 네트워크 변수(AZ 간 왕복시간)를 최소화한다 — TASK-PRESIGN-BOTTLENECK-FIX.md의
+# "같은 리전, 가능하면 같은 VPC/AZ" 권고를 그대로 반영.
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "${var.name_prefix}-vpc"
+  }
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = {
+    Name = "${var.name_prefix}-igw"
+  }
+}
+
+# App/k6 EC2, RDS, ElastiCache가 실제로 배치되는 주 서브넷.
+resource "aws_subnet" "primary" {
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = var.public_subnet_primary_cidr
+  availability_zone       = var.availability_zone_primary
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "${var.name_prefix}-subnet-primary"
+  }
+}
+
+# RDS/ElastiCache 서브넷 그룹의 AZ 요구조건을 채우기 위한 서브넷 — 실사용 인스턴스는 없다.
+resource "aws_subnet" "secondary" {
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = var.public_subnet_secondary_cidr
+  availability_zone       = var.availability_zone_secondary
+  map_public_ip_on_launch = false
+
+  tags = {
+    Name = "${var.name_prefix}-subnet-secondary"
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+
+  tags = {
+    Name = "${var.name_prefix}-rt-public"
+  }
+}
+
+resource "aws_route_table_association" "primary" {
+  subnet_id      = aws_subnet.primary.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "secondary" {
+  subnet_id      = aws_subnet.secondary.id
+  route_table_id = aws_route_table.public.id
+}


### PR DESCRIPTION
## ✅ 작업 내용

### EC2+RDS+ElastiCache 분리 부하테스트 인프라
- 로컬 개발 머신 한 대에 앱·DB·Redis·k6를 전부 올려 측정하던 기존 방식에서 벗어나, 앱은 EC2, DB는 RDS, 캐시는 ElastiCache, 부하생성기는 별도 EC2로 완전히 분리한 환경을 Terraform(`terraform/loadtest/`)으로 구축할 수 있다
- 기존 영구 인프라(`terraform/`, S3·CloudFront·IAM)와 완전히 분리된 별도 state를 써서, 반복적으로 apply/destroy해도 영구 인프라에 영향을 주지 않는다
- 모니터링(Prometheus/Grafana)은 의도적으로 EC2에 올리지 않고 로컬을 그대로 재사용한다 — 인프라 분리의 목적 자체가 "여러 프로세스가 CPU를 나눠 쓰는" 로컬 환경의 노이즈 제거이기 때문
- 이번 세션에서 실제로 apply까지 진행해 전체 인프라가 정상 동작함을 검증했다(App EC2 헬스체크 UP, RDS/ElastiCache 연결 확인, `seed-benchmark.sql` 시딩 완료)

### 부하테스트 절차 가이드 문서
- `docs/guide/EC2-RDS-LOADTEST-GUIDE.md`로 이미 배포된 환경에서 Prometheus/Grafana 원격 재조준 → k6 실행 → 병목 지점 확인(PromQL/CloudWatch) → 로컬 대비 성능 지표 비교까지의 절차를 정리했다
- 구축 과정에서 실측으로 발견한 함정 5건(커밋 SHA로는 `git clone --branch --depth 1`이 실패, k6 rpm 저장소 URL 404, CloudFront 개인키 없이는 앱 기동 자체가 실패, RDS `publicly_accessible=false`로 인한 접속 경로 제약, 보안그룹 description의 ASCII 제약)을 트러블슈팅 절에 남겨 재배포 시 반복되지 않게 했다

## 📌 관련 이슈
관련 이슈 없음 — [TASK-PRESIGN-BOTTLENECK-FIX.md](https://github.com/Kookmin-MoP-Yourtrip/YOURTRIP_BE/blob/dev/docs/tasks/TASK-PRESIGN-BOTTLENECK-FIX.md)의 "개선 제안 — 배포 환경(EC2 + RDS) 분리 부하테스트 (미착수)" 항목으로 기록됐던 것을 실행한 작업이다.

## 📚 추가 리팩토링 가능성
- `terraform/loadtest/`용 lightweight CI(`terraform fmt -check`/`terraform validate`만 도는 GitHub Actions)를 추가하면 실제 AWS 리소스 없이도 문법 회귀를 잡을 수 있다.
- App EC2가 부팅 시 t3.micro(1 vCPU)에서 직접 Gradle 빌드를 하는 대신, 로컬에서 미리 빌드한 JAR를 scp로 올리는 방식으로 바꾸면 빌드 시간·메모리 리스크(현재는 임시 스왑으로 완화)를 줄일 수 있다.
- `allow_dev_psql_access` 변수는 현재 RDS가 `publicly_accessible=false`라 실질적으로 무의미하다(변수 설명에 이미 명시) — 추후 SSM Session Manager 포트포워딩을 추가하면 보안그룹을 전혀 열지 않고도 로컬에서 `psql` 검증이 가능해진다.